### PR TITLE
remove boost dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# cmake out of source build directories
+
+build/
+build-*/

--- a/softcut-lib/include/softcut/Assert.h
+++ b/softcut-lib/include/softcut/Assert.h
@@ -1,0 +1,6 @@
+#ifndef Softcut_ASSERT_H
+#define Softcut_ASSERT_H
+
+#define ASSERT_MSG(expr, msg) assert((expr)&&(msg))
+
+#endif // Softcut_ASSERT_H

--- a/softcut-lib/include/softcut/Resampler.h
+++ b/softcut-lib/include/softcut/Resampler.h
@@ -8,9 +8,10 @@
 #include <iostream>
 #include <cmath>
 
-#include <boost/assert.hpp>
+#include "Assert.h"
 #include "Types.h"
 #include "Interpolate.h"
+
 
 // ultra-simple resampling class
 // works on mono output buffer and processes one input sample at a time
@@ -156,7 +157,7 @@ namespace softcut {
             // we need to produce a fractional interpolation coefficient,
             // by "normalizing" to the output phase period
             phase_t p = phase_ + rate_;
-            BOOST_ASSERT_MSG(p >= 0.0, "resampler encountered negative phase");
+            ASSERT_MSG(p >= 0.0, "resampler encountered negative phase");
             auto nf = static_cast<unsigned int>(p);
             if (nf > 0) {
                 phase_t f = 1.0 - phase_;
@@ -174,4 +175,3 @@ namespace softcut {
 }
 
 #endif //SoftcutHEAD_RESAMPLER_H
-

--- a/softcut-lib/include/softcut/Resampler.h
+++ b/softcut-lib/include/softcut/Resampler.h
@@ -12,7 +12,6 @@
 #include "Types.h"
 #include "Interpolate.h"
 
-
 // ultra-simple resampling class
 // works on mono output buffer and processes one input sample at a time
 

--- a/softcut-lib/include/softcut/SoftClip.h
+++ b/softcut-lib/include/softcut/SoftClip.h
@@ -6,7 +6,8 @@
 #define Softcut_SOFTCLIP_H
 
 #include <cmath>
-#include <boost/math/special_functions/sign.hpp>
+
+#include "Utilities.h"
 
 namespace softcut {
 
@@ -42,7 +43,7 @@ namespace softcut {
 
         float processSample(float x) {
             float ax = fabs(x);
-            const float sx = static_cast<float>(boost::math::sign(x));
+            const float sx = static_cast<float>(sign(x));
 
             if (ax > 1.f) {
                 ax = 1.f;

--- a/softcut-lib/include/softcut/Utilities.h
+++ b/softcut-lib/include/softcut/Utilities.h
@@ -20,6 +20,12 @@ namespace softcut {
     }
 #endif
 
+    // https://stackoverflow.com/questions/1903954/is-there-a-standard-sign-function-signum-sgn-in-c-c
+    template <typename T>
+    static int sign(T val) {
+        return (T(0) < val) - (val < T(0));
+    }
+
     // convert a time-to-convergence to a pole coefficient
     // "ref" argument defines the amount of convergence
     // target ratio is e^ref.
@@ -229,7 +235,7 @@ namespace softcut {
         }
     };
 
-    
+
 
     // simple lookup table class
     template<typename T>
@@ -252,5 +258,5 @@ namespace softcut {
 	}
     };
 
- 
+
 }

--- a/softcut-lib/src/FadeCurves.cpp
+++ b/softcut-lib/src/FadeCurves.cpp
@@ -4,9 +4,9 @@
 
 #include <cmath>
 #include <algorithm>
-#include <boost/assert.hpp>
 #include <cstring>
 
+#include "softcut/Assert.h"
 #include "softcut/Interpolate.h"
 #include "softcut/FadeCurves.h"
 
@@ -81,7 +81,7 @@ void FadeCurves::calcRecFade() {
         }
         buf[n] = 1.f;
     } else {
-        BOOST_ASSERT_MSG(false, "undefined fade shape");
+        ASSERT_MSG(false, "undefined fade shape");
     }
     memcpy(recFadeBuf, buf, fadeBufSize*sizeof(float));
 }
@@ -108,14 +108,14 @@ void FadeCurves::calcPreFade() {
             x += phi;
         }
     } else if (recShape == Raised) {
-        BOOST_ASSERT(preShape == Raised);
+        assert(preShape == Raised);
         const float phi = fpi / ( static_cast<float>(nwp*2));
         while (i < nwp) {
             buf[i++] = cosf(x);
             x += phi;
         }
     } else {
-        BOOST_ASSERT_MSG(false, "undefined fade shape");
+        ASSERT_MSG(false, "undefined fade shape");
     }
     while(i<fadeBufSize) { buf[i++] = 0.f; }
     memcpy(preFadeBuf, buf, fadeBufSize*sizeof(float));

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -11,7 +11,6 @@
 
 #include "softcut/ReadWriteHead.h"
 
-
 using namespace softcut;
 using namespace std;
 

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -5,10 +5,12 @@
 #include <limits>
 
 
+#include "softcut/Assert.h"
 #include "softcut/Interpolate.h"
 #include "softcut/Resampler.h"
 
 #include "softcut/ReadWriteHead.h"
+
 
 using namespace softcut;
 using namespace std;
@@ -30,7 +32,7 @@ void ReadWriteHead::processSample(sample_t in, sample_t *out) {
 
     *out = mixFade(head[0].peek(), head[1].peek(), head[0].fade(), head[1].fade());
 
-    BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
+    ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
 
     head[0].poke(in, pre, rec);
     head[1].poke(in, pre, rec);
@@ -47,7 +49,7 @@ void ReadWriteHead::processSample(sample_t in, sample_t *out) {
 void ReadWriteHead::processSampleNoRead(sample_t in, sample_t *out) {
     (void)out;
 
-    BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
+    ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
 
     head[0].poke(in, pre, rec);
     head[1].poke(in, pre, rec);
@@ -64,7 +66,7 @@ void ReadWriteHead::processSampleNoWrite(sample_t in, sample_t *out) {
     (void)in;
     *out = mixFade(head[0].peek(), head[1].peek(), head[0].fade(), head[1].fade());
 
-    BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
+    ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
 
     takeAction(head[0].updatePhase(start, end, loopFlag));
     takeAction(head[1].updatePhase(start, end, loopFlag));

--- a/softcut-lib/src/SubHead.cpp
+++ b/softcut-lib/src/SubHead.cpp
@@ -5,9 +5,11 @@
 #include <string.h>
 #include <limits>
 
+#include "softcut/Assert.h"
 #include "softcut/Interpolate.h"
 #include "softcut/FadeCurves.h"
 #include "softcut/SubHead.h"
+#include "softcut/Utilities.h"
 
 using namespace softcut;
 
@@ -103,7 +105,7 @@ void SubHead::poke(float in, float pre, float rec) {
         return;
     }
 
-    BOOST_ASSERT_MSG(fade_ >= 0.f && fade_ <= 1.f, "bad fade coefficient in poke()");
+    ASSERT_MSG(fade_ >= 0.f && fade_ <= 1.f, "bad fade coefficient in poke()");
 
     preFade_ = pre + (1.f-pre) * fadeCurves->getPreFadeValue(fade_);
     recFade_ = rec * fadeCurves->getRecFadeValue(fade_);
@@ -149,7 +151,7 @@ float SubHead::peek4() {
 
 unsigned int SubHead::wrapBufIndex(int x) {
     x += bufFrames_;
-    BOOST_ASSERT_MSG(x >= 0, "buffer index before masking is non-negative");
+    ASSERT_MSG(x >= 0, "buffer index before masking is non-negative");
     return x & bufMask_;
 }
 
@@ -172,12 +174,12 @@ void SubHead::setBuffer(float *buf, unsigned int frames) {
     buf_  = buf;
     bufFrames_ = frames;
     bufMask_ = frames - 1;
-    BOOST_ASSERT_MSG((bufFrames_ != 0) && !(bufFrames_ & bufMask_), "buffer size is not 2^N");
+    ASSERT_MSG((bufFrames_ != 0) && !(bufFrames_ & bufMask_), "buffer size is not 2^N");
 }
 
 void SubHead::setRate(rate_t rate) {
     rate_ = rate;
-    inc_dir_ = boost::math::sign(rate);
+    inc_dir_ = sign(rate);
     // NB: resampler doesn't handle negative rates.
     // instead we copy the resampler output backwards into the buffer when rate < 0.
     resamp_.setRate(std::fabs(rate));


### PR DESCRIPTION
### motivation

Following the [README](https://github.com/monome/softcut-lib/blob/master/readme.md) I didn't manage to build the project since I was missing the boost dependency.

Considering this is a lib to be likely used within environments like pure-data, supercollider or max/msp, reducing the amount dependencies required to build it seems desirable.

### implementation notes

`BOOST_ASSERT_MSG` has been replace with a very simple `ASSERT_MSG` which is functinoally different, so I might miss out on some intended use cases.