### PR TITLE
Add voice ducking

### DIFF
--- a/clients/softcut-jack-osc/assets/ducking.scd
+++ b/clients/softcut-jack-osc/assets/ducking.scd
@@ -1,0 +1,84 @@
+n = NetAddr("localhost", 9999);
+
+// mix to softcut
+n.sendMsg("/set/level/adc_cut", 1.0);
+
+
+// mix to DAC
+
+
+/// voice 1, playing, not recording, ducking voice 2
+n.sendMsg("/set/level/cut", 0, 0.6);
+n.sendMsg("/set/param/cut/buffer", 0, 0);
+n.sendMsg("/set/pan/cut", 0, -0.9);
+n.sendMsg("/set/enabled/cut", 0, 1.0);
+
+n.sendMsg("/set/param/cut/rate", 0, -1.0);
+n.sendMsg("/set/param/cut/loop_start", 0, 1.6);
+n.sendMsg("/set/param/cut/loop_end", 0, 4.0);
+
+n.sendMsg("/set/param/cut/loop_flag", 0, 1.0);
+n.sendMsg("/set/param/cut/fade_time", 0, 0.125);
+n.sendMsg("/set/param/cut/rec_level", 0, 1.0);
+n.sendMsg("/set/param/cut/pre_level", 0, 0.0);
+n.sendMsg("/set/param/cut/rec_flag", 0, 0);
+n.sendMsg("/set/param/cut/play_flag", 0, 1);
+n.sendMsg("/set/param/cut/position", 0, 1);
+n.sendMsg("/set/param/cut/duck", 0, 1);
+
+
+/// voice 2, recording and playing
+n.sendMsg("/set/level/in_cut", 0, 1, 1.0);
+n.sendMsg("/set/level/in_cut", 1, 1, 1.0);
+n.sendMsg("/set/param/cut/buffer", 1, 0);
+n.sendMsg("/set/level/cut", 1, 0.98);
+n.sendMsg("/set/pan/cut", 1, 0);
+n.sendMsg("/set/enabled/cut", 1, 1.0);
+
+n.sendMsg("/set/param/cut/rate", 1, 0.5);
+n.sendMsg("/set/param/cut/loop_start", 1, 0.5);
+n.sendMsg("/set/param/cut/loop_end", 1, 4.333);
+n.sendMsg("/set/param/cut/loop_flag", 1, 1.0);
+n.sendMsg("/set/param/cut/fade_time", 1, 0.25);
+n.sendMsg("/set/param/cut/rec_level", 1, 1);
+n.sendMsg("/set/param/cut/pre_level", 1, 0.65);
+n.sendMsg("/set/param/cut/rec_flag", 1, 1);
+n.sendMsg("/set/param/cut/play_flag", 1, 1);
+n.sendMsg("/set/param/cut/position", 1, 0);
+n.sendMsg("/set/param/cut/duck", 1, -1);
+
+
+/// voice 3, playing, not recording, ducking voice 2
+n.sendMsg("/set/level/cut", 2, 0.6);
+n.sendMsg("/set/param/cut/buffer", 2, 0);
+n.sendMsg("/set/pan/cut", 2, 0.9);
+n.sendMsg("/set/enabled/cut", 2, 1.0);
+
+n.sendMsg("/set/param/cut/rate", 2, -1.5);
+n.sendMsg("/set/param/cut/loop_start", 2, 0.1);
+n.sendMsg("/set/param/cut/loop_end", 2, 2.2);
+
+n.sendMsg("/set/param/cut/loop_flag", 2, 1.0);
+n.sendMsg("/set/param/cut/fade_time", 2, 0.0125);
+n.sendMsg("/set/param/cut/rec_level", 2, 1.0);
+n.sendMsg("/set/param/cut/pre_level", 2, 0.0);
+n.sendMsg("/set/param/cut/rec_flag", 2, 0);
+n.sendMsg("/set/param/cut/play_flag", 2, 1);
+n.sendMsg("/set/param/cut/position", 2, 1);
+n.sendMsg("/set/param/cut/duck", 2, 1);
+
+
+/// route 1+3 back to 2 for a little shimmer
+n.sendMsg("/set/level/cut_cut", 0, 1, 0.2);
+n.sendMsg("/set/level/cut_cut", 2, 1, 0.2);
+
+
+n.sendMsg("/set/level/cut_cut", 0, 1, 0.0);
+n.sendMsg("/set/level/cut_cut", 2, 1, 0.0);
+
+// no duck
+/*
+n.sendMsg("/set/param/cut/duck", 0, -1);
+n.sendMsg("/set/param/cut/duck", 2, -1);
+*/
+

--- a/clients/softcut-jack-osc/src/Commands.h
+++ b/clients/softcut-jack-osc/src/Commands.h
@@ -19,53 +19,51 @@ namespace softcut_jack_osc {
 
             // mix
             SET_ENABLED_CUT,
-            SET_LEVEL_CUT,
-            SET_PAN_CUT,
+            SET_CUT_VOICE_LEVEL,
+            SET_CUT_VOICE_PAN,
             // level of individual input channel -> cut voice
             // (separate commands just to avoid a 3rd parameter)
             SET_LEVEL_IN_CUT,
             SET_LEVEL_CUT_CUT,
 
-            // params
-            SET_CUT_REC_ENABLED,
-            SET_CUT_PLAY_ENABLED,
+            // voice parameters
+            SET_CUT_VOICE_BUFFER,
+            SET_CUT_VOICE_REC_ENABLED,
+            SET_CUT_VOICE_PLAY_ENABLED,
 
-            SET_CUT_RATE,
-            SET_CUT_LOOP_START,
-            SET_CUT_LOOP_END,
-            SET_CUT_LOOP_ENABLED,
-            SET_CUT_POSITION,
+            SET_CUT_VOICE_RATE,
+            SET_CUT_VOICE_LOOP_START,
+            SET_CUT_VOICE_LOOP_END,
+            SET_CUT_VOICE_LOOP_ENABLED,
+            SET_CUT_VOICE_POSITION,
 
-            SET_CUT_FADE_TIME,
-            SET_CUT_REC_LEVEL,
-            SET_CUT_PRE_LEVEL,
-            SET_CUT_REC_OFFSET,
+            SET_CUT_VOICE_FADE_TIME,
+            SET_CUT_VOICE_REC_LEVEL,
+            SET_CUT_VOICE_PRE_LEVEL,
+            SET_CUT_VOICE_REC_OFFSET,
 
-            SET_CUT_PRE_FILTER_FC,
-            SET_CUT_PRE_FILTER_FC_MOD,
-            SET_CUT_PRE_FILTER_Q,
-            SET_CUT_PRE_FILTER_ENABLED,
-//            SET_CUT_PRE_FILTER_RQ,
-//            SET_CUT_PRE_FILTER_LP,
-//            SET_CUT_PRE_FILTER_HP,
-//            SET_CUT_PRE_FILTER_BP,
-//            SET_CUT_PRE_FILTER_BR,
-//            SET_CUT_PRE_FILTER_DRY,
+            SET_CUT_VOICE_PRE_FILTER_FC,
+            SET_CUT_VOICE_PRE_FILTER_FC_MOD,
+            SET_CUT_VOICE_PRE_FILTER_Q,
+            SET_CUT_VOICE_PRE_FILTER_ENABLED,
 
-	        SET_CUT_POST_FILTER_FC,
-	        SET_CUT_POST_FILTER_RQ,
-            SET_CUT_POST_FILTER_LP,
-            SET_CUT_POST_FILTER_HP,
-            SET_CUT_POST_FILTER_BP,
-            SET_CUT_POST_FILTER_BR,
-            SET_CUT_POST_FILTER_DRY,
+	        SET_CUT_VOICE_POST_FILTER_FC,
+	        SET_CUT_VOICE_POST_FILTER_RQ,
+            SET_CUT_VOICE_POST_FILTER_LP,
+            SET_CUT_VOICE_POST_FILTER_HP,
+            SET_CUT_VOICE_POST_FILTER_BP,
+            SET_CUT_VOICE_POST_FILTER_BR,
+            SET_CUT_VOICE_POST_FILTER_DRY,
 
-            SET_CUT_LEVEL_SLEW_TIME,
-            SET_CUT_PAN_SLEW_TIME,
-            SET_CUT_RECPRE_SLEW_TIME,
-            SET_CUT_RATE_SLEW_TIME,
+            SET_CUT_VOICE_LEVEL_SLEW_TIME,
+            SET_CUT_VOICE_PAN_SLEW_TIME,
+            SET_CUT_VOICE_RECPRE_SLEW_TIME,
+            SET_CUT_VOICE_RATE_SLEW_TIME,
+
             SET_CUT_VOICE_SYNC,
-            SET_CUT_BUFFER,
+            SET_CUT_VOICE_DUCK_TARGET,
+            SET_CUT_VOICE_FOLLOW_TARGET,
+
             NUM_COMMANDS,
         } Id;
 

--- a/clients/softcut-jack-osc/src/OscInterface.cpp
+++ b/clients/softcut-jack-osc/src/OscInterface.cpp
@@ -122,8 +122,6 @@ void OscInterface::addServerMethods() {
         vuPoll->stop();
     });
 
-
-
     //--------------------------------
     //-- softcut routing
 
@@ -134,18 +132,17 @@ void OscInterface::addServerMethods() {
 
     addServerMethod("/set/level/cut", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_LEVEL_CUT, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_LEVEL, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/pan/cut", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_PAN_CUT, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PAN, argv[0]->i, argv[1]->f);
     });
-
-
 
     //--- NB: these are handled by the softcut command queue,
     // because their corresponding mix points are processed by the softcut client.
+    // (it's arbitrary.)
 
     // input channel -> voice levels
     addServerMethod("/set/level/in_cut", "iif", [](lo_arg **argv, int argc) {
@@ -153,160 +150,126 @@ void OscInterface::addServerMethods() {
         Commands::softcutCommands.post(Commands::Id::SET_LEVEL_IN_CUT, argv[0]->i, argv[1]->i, argv[2]->f);
     });
 
-
     // voice ->  voice levels
     addServerMethod("/set/level/cut_cut", "iif", [](lo_arg **argv, int argc) {
         if (argc < 3) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_LEVEL_CUT_CUT, argv[0]->i, argv[1]->i, argv[2]->f);
     });
 
-
     //--------------------------------
     //-- softcut params
 
-
     addServerMethod("/set/param/cut/rate", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_RATE, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_RATE, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/loop_start", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_LOOP_START, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_LOOP_START, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/loop_end", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_LOOP_END, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_LOOP_END, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/loop_flag", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_LOOP_ENABLED, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_LOOP_ENABLED, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/fade_time", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_FADE_TIME, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_FADE_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rec_level", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_LEVEL, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_REC_LEVEL, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_level", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_LEVEL, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PRE_LEVEL, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rec_flag", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_ENABLED, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_REC_ENABLED, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/play_flag", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_PLAY_ENABLED, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PLAY_ENABLED, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rec_offset", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_OFFSET, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_REC_OFFSET, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/position", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POSITION, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POSITION, argv[0]->i, argv[1]->f);
     });
 
     // --- input filter
     addServerMethod("/set/param/cut/pre_filter_fc", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_FC, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PRE_FILTER_FC, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_fc_mod", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_FC_MOD, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PRE_FILTER_FC_MOD, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_q", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_Q, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PRE_FILTER_Q, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_enabled", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_ENABLED, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PRE_FILTER_ENABLED, argv[0]->i, argv[1]->f);
     });
-
-//    addServerMethod("/set/param/cut/pre_filter_rq", "if", [](lo_arg **argv, int argc) {
-//        if (argc < 2) { return; }
-//        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_RQ, argv[0]->i, argv[1]->f);
-//    });
-//
-//    addServerMethod("/set/param/cut/pre_filter_lp", "if", [](lo_arg **argv, int argc) {
-//        if (argc < 2) { return; }
-//        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_LP, argv[0]->i, argv[1]->f);
-//    });
-//
-//    addServerMethod("/set/param/cut/pre_filter_hp", "if", [](lo_arg **argv, int argc) {
-//        if (argc < 2) { return; }
-//        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_HP, argv[0]->i, argv[1]->f);
-//    });
-//
-//    addServerMethod("/set/param/cut/pre_filter_bp", "if", [](lo_arg **argv, int argc) {
-//        if (argc < 2) { return; }
-//        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_BP, argv[0]->i, argv[1]->f);
-//    });
-//
-//    addServerMethod("/set/param/cut/pre_filter_br", "if", [](lo_arg **argv, int argc) {
-//        if (argc < 2) { return; }
-//        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_BR, argv[0]->i, argv[1]->f);
-//    });
-//
-//    addServerMethod("/set/param/cut/pre_filter_dry", "if", [](lo_arg **argv, int argc) {
-//        if (argc < 2) { return; }
-//        Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_DRY, argv[0]->i, argv[1]->f);
-//    });
-//
 
     // --- output filter
     addServerMethod("/set/param/cut/post_filter_fc", "if", [
     ](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_FC, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POST_FILTER_FC, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_rq", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_RQ, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POST_FILTER_RQ, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_lp", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_LP, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POST_FILTER_LP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_hp", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_HP, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POST_FILTER_HP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_bp", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_BP, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POST_FILTER_BP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_br", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_BR, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POST_FILTER_BR, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_dry", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_DRY, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_POST_FILTER_DRY, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/voice_sync", "iif", [](lo_arg **argv, int argc) {
@@ -316,36 +279,38 @@ void OscInterface::addServerMethods() {
 
     addServerMethod("/set/param/cut/level_slew_time", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_LEVEL_SLEW_TIME, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_LEVEL_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pan_slew_time", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_PAN_SLEW_TIME, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_PAN_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/recpre_slew_time", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_RECPRE_SLEW_TIME, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_RECPRE_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rate_slew_time", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_RATE_SLEW_TIME, argv[0]->i, argv[1]->f);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_RATE_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
-
 
     addServerMethod("/set/param/cut/buffer", "ii", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_BUFFER, argv[0]->i, argv[1]->i);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_BUFFER, argv[0]->i, argv[1]->i);
+    });
+
+    addServerMethod("/set/param/cut/duck", "ii", [](lo_arg **argv, int argc) {
+        if (argc < 2) { return; }
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_DUCK_TARGET,argv[0]->i, argv[1]->i);
     });
 
 
     //-------------------------------
     //--- softcut buffer manipulation
 
-
-    // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
     addServerMethod("/softcut/buffer/read_mono", "sfffii", [](lo_arg **argv, int argc) {
         float startSrc = 0.f;
         float startDst = 0.f;
@@ -376,7 +341,6 @@ void OscInterface::addServerMethods() {
 
     });
 
-    // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
     addServerMethod("/softcut/buffer/read_stereo", "sfff", [](lo_arg **argv, int argc) {
         float startSrc = 0.f;
         float startDst = 0.f;
@@ -398,8 +362,6 @@ void OscInterface::addServerMethods() {
         softCutClient->readBufferStereo(str, startSrc, startDst, dur);
     });
 
-
-    // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
     addServerMethod("/softcut/buffer/write_mono", "sffi", [](lo_arg **argv, int argc) {
         float start = 0.f;
         float dur = -1.f;
@@ -421,7 +383,6 @@ void OscInterface::addServerMethods() {
         softCutClient->writeBufferMono(str, start, dur, chan);
     });
 
-    // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
     addServerMethod("/softcut/buffer/write_stereo", "sff", [](lo_arg **argv, int argc) {
         float start = 0.f;
         float dur = -1.f;

--- a/clients/softcut-jack-osc/src/SoftcutClient.cpp
+++ b/clients/softcut-jack-osc/src/SoftcutClient.cpp
@@ -16,13 +16,11 @@ static inline void clamp(size_t &x, const size_t a) {
 }
 
 SoftcutClient::SoftcutClient() : JackClient<2, 2>("softcut") {
-
     for (unsigned int i = 0; i < NumVoices; ++i) {
-        cut.setVoiceBuffer(i, buf[i & 1], BufFrames);
+        cut.voice(i)->setBuffer(buf[i & 1], BufFrames);
     }
     bufIdx[0] = BufDiskWorker::registerBuffer(buf[0], BufFrames);
     bufIdx[1] = BufDiskWorker::registerBuffer(buf[1], BufFrames);
-
 }
 
 void SoftcutClient::process(jack_nframes_t numFrames) {
@@ -43,7 +41,6 @@ void SoftcutClient::setSampleRate(jack_nframes_t sr) {
     cut.setSampleRate(sr);
 }
 
-
 void SoftcutClient::clearBusses(size_t numFrames) {
     mix.clear(numFrames);
     for (auto &b : input) { b.clear(numFrames); }
@@ -51,12 +48,12 @@ void SoftcutClient::clearBusses(size_t numFrames) {
 
 void SoftcutClient::mixInput(size_t numFrames) {
     for (int dst = 0; dst < NumVoices; ++dst) {
-        if (cut.getRecFlag(dst)) {
+        if (cut.voice(dst)->getRecFlag()) {
             for (int ch = 0; ch < 2; ++ch) {
                 input[dst].mixFrom(&source[SourceAdc][ch], numFrames, inLevel[ch][dst]);
             }
             for (int src = 0; src < NumVoices; ++src) {
-                if (cut.getPlayFlag(src)) {
+                if (cut.voice(src)->getPlayFlag()) {
                     input[dst].mixFrom(output[src], numFrames, fbLevel[src][dst]);
                 }
             }
@@ -66,7 +63,7 @@ void SoftcutClient::mixInput(size_t numFrames) {
 
 void SoftcutClient::mixOutput(size_t numFrames) {
     for (int v = 0; v < NumVoices; ++v) {
-        if (cut.getPlayFlag(v)) {
+        if (cut.voice(v)->getPlayFlag()) {
             mix.panMixEpFrom(output[v], numFrames, outLevel[v], outPan[v]);
         }
     }
@@ -74,15 +71,9 @@ void SoftcutClient::mixOutput(size_t numFrames) {
 
 void SoftcutClient::handleCommand(Commands::CommandPacket *p) {
     switch (p->id) {
-        //-- softcut routing
+        //-- client routing and levels
         case Commands::Id::SET_ENABLED_CUT:
             enabled[p->idx_0] = p->value > 0.f;
-            break;
-        case Commands::Id::SET_LEVEL_CUT:
-            outLevel[p->idx_0].setTarget(p->value);
-            break;;
-        case Commands::Id::SET_PAN_CUT:
-            outPan[p->idx_0].setTarget((p->value/2)+0.5); // map -1,1 to 0,1
             break;
         case Commands::Id::SET_LEVEL_IN_CUT:
             inLevel[p->idx_0][p->idx_1].setTarget(p->value);
@@ -90,94 +81,110 @@ void SoftcutClient::handleCommand(Commands::CommandPacket *p) {
         case Commands::Id::SET_LEVEL_CUT_CUT:
             fbLevel[p->idx_0][p->idx_1].setTarget(p->value);
             break;
-            //-- softcut commands
-        case Commands::Id::SET_CUT_RATE:
-            cut.setRate(p->idx_0, p->value);
+
+            //-- voice levels, pan
+        case Commands::Id::SET_CUT_VOICE_PAN:
+            outPan[p->idx_0].setTarget((p->value / 2) + 0.5); // map -1,1 to 0,1
             break;
-        case Commands::Id::SET_CUT_LOOP_START:
-            cut.setLoopStart(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_LOOP_END:
-            cut.setLoopEnd(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_LOOP_ENABLED:
-            cut.setLoopFlag(p->idx_0, p->value > 0.f);
-            break;
-        case Commands::Id::SET_CUT_FADE_TIME:
-            cut.setFadeTime(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_REC_LEVEL:
-            cut.setRecLevel(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_LEVEL:
-            cut.setPreLevel(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_REC_ENABLED:
-            cut.setRecFlag(p->idx_0, p->value > 0.f);
-            break;
-        case Commands::Id::SET_CUT_PLAY_ENABLED:
-            cut.setPlayFlag(p->idx_0, p->value > 0.f);
-            break;
-        case Commands::Id::SET_CUT_REC_OFFSET:
-            cut.setRecOffset(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POSITION:
-            cut.setPosition(p->idx_0, p->value);
-            break;
-            // input filter
-        case Commands::Id::SET_CUT_PRE_FILTER_FC:
-            cut.setPreFilterFc(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_FC_MOD:
-            cut.setPreFilterFcMod(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_Q:
-            cut.setPreFilterQ(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_ENABLED:
-            cut.setPreFilterEnabled(p->idx_0, p->value > 0);
-            break;
-            // output filter
-        case Commands::Id::SET_CUT_POST_FILTER_FC:
-            cut.setPostFilterFc(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_RQ:
-            cut.setPostFilterRq(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_LP:
-            cut.setPostFilterLp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_HP:
-            cut.setPostFilterHp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_BP:
-            cut.setPostFilterBp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_BR:
-            cut.setPostFilterBr(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_DRY:
-            cut.setPostFilterDry(p->idx_0, p->value);
+        case Commands::Id::SET_CUT_VOICE_LEVEL:
+            outLevel[p->idx_0].setTarget(p->value);
             break;
 
-        case Commands::Id::SET_CUT_LEVEL_SLEW_TIME:
+            //-- voice commands
+        case Commands::Id::SET_CUT_VOICE_BUFFER:
+            cut.voice(p->idx_0)->setBuffer(buf[p->idx_1], BufFrames);
+            break;
+        case Commands::Id::SET_CUT_VOICE_REC_ENABLED:
+            cut.voice(p->idx_0)->setRecFlag(p->value > 0.f);
+            break;
+        case Commands::Id::SET_CUT_VOICE_PLAY_ENABLED:
+            cut.voice(p->idx_0)->setPlayFlag(p->value > 0.f);
+            break;
+        case Commands::Id::SET_CUT_VOICE_RATE:
+            cut.voice(p->idx_0)->setRate(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_LOOP_START:
+            cut.voice(p->idx_0)->setLoopStart(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_LOOP_END:
+            cut.voice(p->idx_0)->setLoopEnd(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_LOOP_ENABLED:
+            cut.voice(p->idx_0)->setLoopFlag(p->value > 0.f);
+            break;
+        case Commands::Id::SET_CUT_VOICE_FADE_TIME:
+            cut.voice(p->idx_0)->setFadeTime(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_REC_LEVEL:
+            cut.voice(p->idx_0)->setRecLevel(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_PRE_LEVEL:
+            cut.voice(p->idx_0)->setPreLevel(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_REC_OFFSET:
+            cut.voice(p->idx_0)->setRecOffset(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_POSITION:
+            cut.voice(p->idx_0)->setPosition(p->value);
+            break;
+
+            //-- input filter
+        case Commands::Id::SET_CUT_VOICE_PRE_FILTER_FC:
+            cut.voice(p->idx_0)->setPreFilterFc(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_PRE_FILTER_FC_MOD:
+            cut.voice(p->idx_0)->setPreFilterFcMod(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_PRE_FILTER_Q:
+            cut.voice(p->idx_0)->setPreFilterQ(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_PRE_FILTER_ENABLED:
+            cut.voice(p->idx_0)->setPreFilterEnabled(p->value > 0);
+            break;
+
+            //-- output filter
+        case Commands::Id::SET_CUT_VOICE_POST_FILTER_FC:
+            cut.voice(p->idx_0)->setPostFilterFc(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_POST_FILTER_RQ:
+            cut.voice(p->idx_0)->setPostFilterRq(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_POST_FILTER_LP:
+            cut.voice(p->idx_0)->setPostFilterLp(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_POST_FILTER_HP:
+            cut.voice(p->idx_0)->setPostFilterHp(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_POST_FILTER_BP:
+            cut.voice(p->idx_0)->setPostFilterBp(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_POST_FILTER_BR:
+            cut.voice(p->idx_0)->setPostFilterBr(p->value);
+            break;
+        case Commands::Id::SET_CUT_VOICE_POST_FILTER_DRY:
+            cut.voice(p->idx_0)->setPostFilterDry(p->value);
+            break;
+
+            //-- slew times
+        case Commands::Id::SET_CUT_VOICE_LEVEL_SLEW_TIME:
             outLevel[p->idx_0].setTime(p->value);
             break;
-        case Commands::Id::SET_CUT_PAN_SLEW_TIME:
+        case Commands::Id::SET_CUT_VOICE_PAN_SLEW_TIME:
             outPan[p->idx_0].setTime(p->value);
             break;
-        case Commands::Id::SET_CUT_RECPRE_SLEW_TIME:
-            cut.setRecPreSlewTime(p->idx_0, p->value);
+        case Commands::Id::SET_CUT_VOICE_RECPRE_SLEW_TIME:
+            cut.voice(p->idx_0)->setRecPreSlewTime(p->value);
             break;
-        case Commands::Id::SET_CUT_RATE_SLEW_TIME:
-            cut.setRateSlewTime(p->idx_0, p->value);
+        case Commands::Id::SET_CUT_VOICE_RATE_SLEW_TIME:
+            cut.voice(p->idx_0)->setRateSlewTime(p->value);
             break;
+
+            //-- sync / inter-voice
         case Commands::Id::SET_CUT_VOICE_SYNC:
             cut.syncVoice(p->idx_0, p->idx_1, p->value);
             break;
-        case Commands::Id::SET_CUT_BUFFER:
-            cut.setVoiceBuffer(p->idx_0, buf[p->idx_1], BufFrames);
-            break;
+        case Commands::Id::SET_CUT_VOICE_DUCK_TARGET:
+            cut.voice(p->idx_0)->setDuckTarget(cut.voice(p->idx_1));
         default:;;
     }
 }
@@ -185,7 +192,7 @@ void SoftcutClient::handleCommand(Commands::CommandPacket *p) {
 void SoftcutClient::reset() {
 
     for (int v = 0; v < NumVoices; ++v) {
-        cut.setVoiceBuffer(v, buf[v%2], BufFrames);
+        cut.voice(v)->setBuffer(buf[v % 2], BufFrames);
         outLevel[v].setTarget(0.f);
         outLevel->setTime(0.001);
         outPan[v].setTarget(0.5f);
@@ -196,18 +203,18 @@ void SoftcutClient::reset() {
         setPhaseQuant(v, 1.f);
         setPhaseOffset(v, 0.f);
 
-        for (int i=0; i<2; ++i) {
+        for (int i = 0; i < 2; ++i) {
             inLevel[i][v].setTime(0.001);
             inLevel[i][v].setTarget(0.0);
         }
 
-        for (int w=0; w<NumVoices; ++w) {
+        for (int w = 0; w < NumVoices; ++w) {
             fbLevel[v][w].setTime(0.001);
             fbLevel[v][w].setTarget(0.0);
         }
 
-        cut.setLoopStart(v, v*2);
-        cut.setLoopEnd(v, v*2 + 1);
+        cut.voice(v)->setLoopStart(v * 2);
+        cut.voice(v)->setLoopEnd(v * 2 + 1);
 
         output[v].clear();
         input[v].clear();

--- a/clients/softcut-jack-osc/src/SoftcutClient.h
+++ b/clients/softcut-jack-osc/src/SoftcutClient.h
@@ -14,7 +14,6 @@
 #include "softcut/Softcut.h"
 #include "softcut/Types.h"
 
-
 namespace softcut_jack_osc {
     class SoftcutClient: public JackClient<2, 2> {
     public:
@@ -89,26 +88,29 @@ namespace softcut_jack_osc {
         }
 
         // check if quantized phase has changed for a given voice
-        // returns true
+        // returns true if changed
         bool checkVoiceQuantPhase(int i) {
-            if (quantPhase[i] != cut.getQuantPhase(i)) {
-                quantPhase[i] = cut.getQuantPhase(i);
+            auto qp = cut.voice(i)->getQuantPhase();
+            if (quantPhase[i] != qp) {
+                quantPhase[i] = qp;
                 return true;
             } else {
                 return false;
             }
         }
         softcut::phase_t getQuantPhase(int i) {
-            return cut.getQuantPhase(i);
-        }
-        void setPhaseQuant(int i, softcut::phase_t q) {
-            cut.setPhaseQuant(i, q);
-        }
-        void setPhaseOffset(int i, float sec) {
-            cut.setPhaseOffset(i, sec);
+            return cut.voice(i)->getQuantPhase();
         }
 
-        int getNumVoices() const { return NumVoices; }
+        void setPhaseQuant(int i, softcut::phase_t q) {
+            cut.voice(i)->setPhaseQuant(q);
+        }
+
+        void setPhaseOffset(int i, float sec) {
+            cut.voice(i)->setPhaseOffset(sec);
+        }
+
+        [[nodiscard]] int getNumVoices() const { return NumVoices; }
 
 	void reset();
 

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -14,6 +14,7 @@ namespace softcut {
     class ReadWriteHead {
 
     protected:
+        friend class Voice;
         friend class SubHead;
         friend class TestBuffers;
 
@@ -102,11 +103,11 @@ namespace softcut {
 
         void setRecOffsetSamples(int d);
 
-        phase_t getActivePhase();
+        phase_t getActivePhase() const;
 
         phase_t wrapPhaseToLoop(phase_t p);
 
-        frame_t wrapFrameToLoopFade(frame_t w);
+//        frame_t wrapFrameToLoopFade(frame_t w);
 
         static constexpr size_t maxBlockSize = SubHead::maxBlockSize;
 

--- a/softcut-lib/include/softcut/Softcut.h
+++ b/softcut-lib/include/softcut/Softcut.h
@@ -14,17 +14,12 @@ namespace softcut {
     template<int numVoices>
     class Softcut {
     protected:
+
         friend class TestBuffers;
 
+    private:
+        Voice scv[numVoices];
     public:
-
-//        Softcut(sample_t **buffers, size_t numBuffers, size_t numFrames) {
-//
-//            for (int v = 0; v < numVoices; ++v) {
-//                scv[v].setBuffer(buffers[v % numBuffers], numFrames);
-//            };
-//            this->reset();
-//        }
 
         Softcut() {
             this->reset();
@@ -33,7 +28,14 @@ namespace softcut {
         void reset() {
             for (int v = 0; v < numVoices; ++v) {
                 scv[v].reset();
+                /// test: set each voice to duck the next one, in a loop
+                scv[v].setDuckTarget( &(scv[(v+1)%numVoices]) );
+                // test: set voices to duck each other in pairs
+                //// (FIXME: probably won't work right because each voice processes whole block in turn...)
+//                scv[0].setDuckTarget(&(scv[1]));
+//                scv[1].setDuckTarget(&(scv[0]));
             };
+
         }
 
         // assumption: v is in range
@@ -47,209 +49,18 @@ namespace softcut {
             }
         }
 
-        void setRate(int voice, float rate) {
-            scv[voice].setRate(rate);
+        Voice *voice(int i) {
+            if (i >= 0 && i < numVoices) {
+                return &(scv[i]);
+            } else {
+                return nullptr;
+            }
         }
 
-        void setLoopStart(int voice, float sec) {
-            scv[voice].setLoopStart(sec);
+
+        void syncVoice(int follower, int leader, float offset) {
+            // TODO
         }
-
-        void setLoopEnd(int voice, float sec) {
-            scv[voice].setLoopEnd(sec);
-        }
-
-        void setLoopFlag(int voice, bool val) {
-            scv[voice].setLoopFlag(val);
-        }
-
-        void setFadeTime(int voice, float sec) {
-            scv[voice].setFadeTime(sec);
-        }
-
-        void setRecLevel(int voice, float amp) {
-            scv[voice].setRecLevel(amp);
-        }
-
-        void setPreLevel(int voice, float amp) {
-            scv[voice].setPreLevel(amp);
-        }
-
-        void setRecFlag(int voice, bool val) {
-            scv[voice].setRecFlag(val);
-        }
-
-        void setPlayFlag(int voice, bool val) {
-            scv[voice].setPlayFlag(val);
-        }
-
-        void setPosition(int voice, float sec) {
-            scv[voice].setPosition(sec);
-        }
-
-        void setPreFilterFc(int voice, float x) {
-            (void) voice;
-            (void) x;
-            scv[voice].setPreFilterFc(x);
-        }
-
-        void setPreFilterRq(int voice, float x) {
-            (void) voice;
-            (void) x;
-            // FIXME: disabled for now
-            // scv[voice].setPreFilterRq(x);
-        }
-
-        void setPreFilterLp(int voice, float x) {
-            (void) voice;
-            (void) x;
-            // FIXME: disabled for now
-            // scv[voice].setPreFilterLp(x);
-        }
-
-        void setPreFilterHp(int voice, float x) {
-            (void) voice;
-            (void) x;
-            // FIXME: disabled for now
-            // scv[voice].setPreFilterHp(x);
-        }
-
-        void setPreFilterBp(int voice, float x) {
-            (void) voice;
-            (void) x;
-            // FIXME: disabled for now
-            // scv[voice].setPreFilterBp(x);
-        }
-
-        void setPreFilterBr(int voice, float x) {
-            (void) voice;
-            (void) x;
-            // FIXME: disabled for now
-            // scv[voice].setPreFilterBr(x);
-        }
-
-        void setPreFilterDry(int voice, float x) {
-            (void) voice;
-            (void) x;
-            // FIXME: disabled for now
-            // scv[voice].setPreFilterDry(x);
-        }
-
-        void setPreFilterFcMod(int voice, float x) {
-            scv[voice].setPreFilterFcMod(x);
-        }
-
-        void setPostFilterFc(int voice, float x) {
-            scv[voice].setPostFilterFc(x);
-        }
-
-        void setPostFilterRq(int voice, float x) {
-            scv[voice].setPostFilterRq(x);
-        }
-
-        void setPostFilterLp(int voice, float x) {
-            scv[voice].setPostFilterLp(x);
-        }
-
-        void setPostFilterHp(int voice, float x) {
-            scv[voice].setPostFilterHp(x);
-        }
-
-        void setPostFilterBp(int voice, float x) {
-            scv[voice].setPostFilterBp(x);
-        }
-
-        void setPostFilterBr(int voice, float x) {
-            scv[voice].setPostFilterBr(x);
-        }
-
-        void setPostFilterDry(int voice, float x) {
-            scv[voice].setPostFilterDry(x);
-        }
-
-#if 0 // not allowing realtime manipulation of fade logic params
-        void setPreFadeWindow(float x) {
-    auto t = std::thread([x] {
-        FadeCurves::setPreWindowRatio(x);
-    });
-    t.detach();
-}
-
-void setRecFadeDelay(float x) {
-    auto t = std::thread([x] {
-        FadeCurves::setRecDelayRatio(x);
-    });
-    t.detach();
-}
-
-void setPreFadeShape(float x) {
-    auto t = std::thread([x] {
-        FadeCurves::setPreShape(static_cast<FadeCurves::Shape>(x));
-    });
-    t.detach();
-}
-
-void setRecFadeShape(float x) {
-    auto t = std::thread([x] {
-        FadeCurves::setRecShape(static_cast<FadeCurves::Shape>(x));
-    });
-    t.detach();
-}
-#endif
-
-        void setRecOffset(int i, float d) {
-            scv[i].setRecOffset(d);
-        }
-
-        void setLevelSlewTime(int i, float d) {
-            scv[i].setLevelSlewTime(d);
-        }
-
-        void setRecPreSlewTime(int i, float d) {
-            scv[i].setRecPreSlewTime(d);
-        }
-
-        void setRateSlewTime(int i, float d) {
-            scv[i].setRateSlewTime(d);
-        }
-
-        phase_t getQuantPhase(int i) {
-            return scv[i].getQuantPhase();
-        }
-
-        void setPhaseQuant(int i, phase_t q) {
-            scv[i].setPhaseQuant(q);
-        }
-
-        void setPhaseOffset(int i, float sec) {
-            scv[i].setPhaseOffset(sec);
-        }
-
-        bool getRecFlag(int i) {
-            return scv[i].getRecFlag();
-        }
-
-        bool getPlayFlag(int i) {
-            return scv[i].getPlayFlag();
-        }
-
-        void syncVoice(int follow, int lead, float offset) {
-            scv[follow].setPosition(scv[lead].getPos() + offset);
-        }
-
-        void setVoiceBuffer(int i, float *buf, size_t bufFrames) {
-            scv[i].setBuffer(buf, bufFrames);
-        }
-
-        void setPreFilterQ(int i, float x) {
-            scv[i].setPreFilterQ(x);
-        }
-        void setPreFilterEnabled(int i, bool x) {
-            scv[i].setPreFilterEnabled(x);
-        }
-
-    private:
-        Voice scv[numVoices];
     };
 }
 

--- a/softcut-lib/include/softcut/SubHead.h
+++ b/softcut-lib/include/softcut/SubHead.h
@@ -29,7 +29,7 @@ namespace softcut {
     //template <size_t blockSizeExpected>
     class SubHead {
         friend class ReadWriteHead;
-
+        friend class Voice;
         friend class TestBuffers;
 
     public:

--- a/softcut-lib/include/softcut/TestBuffers.h
+++ b/softcut-lib/include/softcut/TestBuffers.h
@@ -99,5 +99,6 @@ namespace softcut {
 
 
     };
+
 }
 #endif

--- a/softcut-lib/include/softcut/Voice.h
+++ b/softcut-lib/include/softcut/Voice.h
@@ -93,11 +93,15 @@ namespace softcut {
 
         phase_t getQuantPhase();
 
-        bool getPlayFlag();
+        bool getPlayFlag() const;
 
-        bool getRecFlag();
+        bool getRecFlag() const;
 
-        float getPos();
+        float getPos() const;
+
+        void setDuckTarget(Voice* v)  {
+            duckTarget = v;
+        }
 
         void reset();
 
@@ -145,6 +149,13 @@ namespace softcut {
         bool playEnabled{};
         bool recEnabled{};
         bool preFilterEnabled;
+
+        const Voice *duckTarget{nullptr};
+        const Voice *followTarget{nullptr};
+
+        void applyDucking(float *out, size_t numFrames);
+
+        static float calcPhaseDuck(double a, double b, float rec, float pre);
     };
 }
 

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -190,7 +190,7 @@ void ReadWriteHead::setPosition(float seconds) {
     enqueuePositionChange(seconds * sr);
 }
 
-phase_t ReadWriteHead::getActivePhase() {
+phase_t ReadWriteHead::getActivePhase() const {
     // TODO
     return 0;
 }
@@ -206,10 +206,10 @@ phase_t ReadWriteHead::wrapPhaseToLoop(phase_t p) {
     }
 }
 
-ReadWriteHead::frame_t ReadWriteHead::wrapFrameToLoopFade(frame_t w) {
-    //frame_t max -
-    return 0;
-}
+//ReadWriteHead::frame_t ReadWriteHead::wrapFrameToLoopFade(frame_t w) {
+//    //frame_t max = ...
+//    return 0;
+//}
 
 float ReadWriteHead::getRateBuffer(size_t i) {
     return rate[i];


### PR DESCRIPTION
adds voice ducking. 

each voice ('follower') can have 1 duck target ('leader'.) when any subhead[*] of follower is close to any currently active subhead of leader (that is, one that is contributing to input,) the follower output is faded out.

([*] just realized a FIXME which is that the follower currently computes with both subheads, but should ignore any that are not contributing to output... )

also could use a little more polish in a couple respects:

1. at the moment, each voice still takes turns performing per-block operations, like:
  - update positions
  - write to buffer, etc

   .. which means that it won't work to have ducking cycles (e.g. voice1 and voice2 both recording, both playing, and each ducking its playback when it crosses the other's record.) 

  but such cycles would be fine if we first processed all voice positions, then rec levels, then playback levels. (simple thing to refactor it this way.)

2. the ducking window is a fixed size (in samples); it's not settable and doesn't e.g. vary with movement rate.

----------

(also in this PR: lots of breaking changes to the `Commands` structure;
they had to be changed anyway, and the OSC interface is mostly non-breaking (pre-filter is different and there is a new command for duck targets.)

for norns v3 i want to automate the generation of all the glue code from lua -> audio thread;
thinking about patterns that will facilicate this)