### PR TITLE
improve / enhance / finish duck, follow, sync

### DIFF
--- a/clients/softcut-jack-osc/assets/ducking.scd
+++ b/clients/softcut-jack-osc/assets/ducking.scd
@@ -10,10 +10,10 @@ n.sendMsg("/set/level/adc_cut", 1.0);
 /// voice 1, playing, not recording, ducking voice 2
 n.sendMsg("/set/level/cut", 0, 0.6);
 n.sendMsg("/set/param/cut/buffer", 0, 0);
-n.sendMsg("/set/pan/cut", 0, -0.9);
+n.sendMsg("/set/pan/cut", 0, -0.3);
 n.sendMsg("/set/enabled/cut", 0, 1.0);
 
-n.sendMsg("/set/param/cut/rate", 0, -1.0);
+n.sendMsg("/set/param/cut/rate", 0, -0.25);
 n.sendMsg("/set/param/cut/loop_start", 0, 1.6);
 n.sendMsg("/set/param/cut/loop_end", 0, 4.0);
 
@@ -51,11 +51,11 @@ n.sendMsg("/set/param/cut/duck", 1, -1);
 /// voice 3, playing, not recording, ducking voice 2
 n.sendMsg("/set/level/cut", 2, 0.6);
 n.sendMsg("/set/param/cut/buffer", 2, 0);
-n.sendMsg("/set/pan/cut", 2, 0.9);
+n.sendMsg("/set/pan/cut", 2, 0.0);
 n.sendMsg("/set/enabled/cut", 2, 1.0);
 
-n.sendMsg("/set/param/cut/rate", 2, -1.5);
-n.sendMsg("/set/param/cut/loop_start", 2, 0.1);
+n.sendMsg("/set/param/cut/rate", 2, -0.5);
+n.sendMsg("/set/param/cut/loop_start", 2, 1.1);
 n.sendMsg("/set/param/cut/loop_end", 2, 2.2);
 
 n.sendMsg("/set/param/cut/loop_flag", 2, 1.0);

--- a/clients/softcut-jack-osc/src/Commands.h
+++ b/clients/softcut-jack-osc/src/Commands.h
@@ -22,7 +22,6 @@ namespace softcut_jack_osc {
             SET_CUT_VOICE_LEVEL,
             SET_CUT_VOICE_PAN,
             // level of individual input channel -> cut voice
-            // (separate commands just to avoid a 3rd parameter)
             SET_LEVEL_IN_CUT,
             SET_LEVEL_CUT_CUT,
 

--- a/clients/softcut-jack-osc/src/Commands.h
+++ b/clients/softcut-jack-osc/src/Commands.h
@@ -60,7 +60,8 @@ namespace softcut_jack_osc {
             SET_CUT_VOICE_RATE_SLEW_TIME,
 
             SET_CUT_VOICE_SYNC,
-            SET_CUT_VOICE_DUCK_TARGET,
+            SET_CUT_VOICE_READ_DUCK_TARGET,
+            SET_CUT_VOICE_WRITE_DUCK_TARGET,
             SET_CUT_VOICE_FOLLOW_TARGET,
 
             NUM_COMMANDS,

--- a/clients/softcut-jack-osc/src/OscInterface.cpp
+++ b/clients/softcut-jack-osc/src/OscInterface.cpp
@@ -473,7 +473,7 @@ void OscInterface::printServerMethods() {
     cout << "osc methods: " << endl;
     for (unsigned int i = 0; i < numMethods; ++i) {
         //cout << format(" %1% [%2%]") % methods[i].path % methods[i].format << endl;
-        cout << methods[i].path << "\t" << methods[i].format << endl;
+        cout << methods[i].path << " [" << methods[i].format << "]" << endl;
     }
 }
 

--- a/clients/softcut-jack-osc/src/OscInterface.cpp
+++ b/clients/softcut-jack-osc/src/OscInterface.cpp
@@ -29,7 +29,6 @@ SoftcutClient *OscInterface::softCutClient;
 OscInterface::OscMethod::OscMethod(string p, string f, OscInterface::Handler h)
         : path(std::move(p)), format(std::move(f)), handler(h) {}
 
-
 void OscInterface::init(SoftcutClient *sc) {
     quitFlag = false;
     // FIXME: should get port configs from program args or elsewhere
@@ -67,13 +66,9 @@ void OscInterface::addServerMethod(const char *path, const char *format, Handler
     OscMethod m(path, format, handler);
     methods[numMethods] = m;
     lo_server_thread_add_method(st, path, format,
-                                [](const char *path,
-                                   const char *types,
-                                   lo_arg **argv,
-                                   int argc,
-                                   lo_message msg,
-                                   void *data)
-                                        -> int {
+                                [](const char *path, const char *types,
+                                   lo_arg **argv, int argc,
+                                   lo_message msg, void *data) -> int {
                                     (void) path;
                                     (void) types;
                                     (void) msg;

--- a/clients/softcut-jack-osc/src/OscInterface.cpp
+++ b/clients/softcut-jack-osc/src/OscInterface.cpp
@@ -297,9 +297,17 @@ void OscInterface::addServerMethods() {
         Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_BUFFER, argv[0]->i, argv[1]->i);
     });
 
-    addServerMethod("/set/param/cut/duck", "ii", [](lo_arg **argv, int argc) {
+    addServerMethod("/set/param/cut/read_duck", "ii", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_DUCK_TARGET,argv[0]->i, argv[1]->i);
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_READ_DUCK_TARGET,argv[0]->i, argv[1]->i);
+    });
+    addServerMethod("/set/param/cut/write_duck", "ii", [](lo_arg **argv, int argc) {
+        if (argc < 2) { return; }
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_WRITE_DUCK_TARGET,argv[0]->i, argv[1]->i);
+    });
+    addServerMethod("/set/param/cut/follow", "ii", [](lo_arg **argv, int argc) {
+        if (argc < 2) { return; }
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_FOLLOW_TARGET,argv[0]->i, argv[1]->i);
     });
 
 

--- a/clients/softcut-jack-osc/src/SoftcutClient.cpp
+++ b/clients/softcut-jack-osc/src/SoftcutClient.cpp
@@ -17,7 +17,9 @@ static inline void clamp(size_t &x, const size_t a) {
 
 SoftcutClient::SoftcutClient() : JackClient<2, 2>("softcut") {
     for (unsigned int i = 0; i < NumVoices; ++i) {
-        cut.voice(i)->setBuffer(buf[i & 1], BufFrames);
+        cut.voice((int)i)->setBuffer(buf[i & 1], BufFrames);
+        cut.setInputBus((int)i, input[i].buf[0]);
+        cut.setOutputBus((int)i, output[i].buf[0]);
     }
     bufIdx[0] = BufDiskWorker::registerBuffer(buf[0], BufFrames);
     bufIdx[1] = BufDiskWorker::registerBuffer(buf[1], BufFrames);
@@ -27,12 +29,7 @@ void SoftcutClient::process(jack_nframes_t numFrames) {
     Commands::softcutCommands.handlePending(this);
     clearBusses(numFrames);
     mixInput(numFrames);
-    // process softcuts (overwrites output bus)
-    for (int v = 0; v < NumVoices; ++v) {
-        if (enabled[v]) {
-            cut.processBlock(v, input[v].buf[0], output[v].buf[0], static_cast<int>(numFrames));
-        }
-    }
+    cut.processBlock(numFrames);
     mixOutput(numFrames);
     mix.copyTo(sink[0], numFrames);
 }
@@ -49,9 +46,11 @@ void SoftcutClient::clearBusses(size_t numFrames) {
 void SoftcutClient::mixInput(size_t numFrames) {
     for (int dst = 0; dst < NumVoices; ++dst) {
         if (cut.voice(dst)->getRecFlag()) {
+            // stereo capture
             for (int ch = 0; ch < 2; ++ch) {
                 input[dst].mixFrom(&source[SourceAdc][ch], numFrames, inLevel[ch][dst]);
             }
+            // feedback matrix
             for (int src = 0; src < NumVoices; ++src) {
                 if (cut.voice(src)->getPlayFlag()) {
                     input[dst].mixFrom(output[src], numFrames, fbLevel[src][dst]);
@@ -73,7 +72,8 @@ void SoftcutClient::handleCommand(Commands::CommandPacket *p) {
     switch (p->id) {
         //-- client routing and levels
         case Commands::Id::SET_ENABLED_CUT:
-            enabled[p->idx_0] = p->value > 0.f;
+            //enabled[p->idx_0] = p->value > 0.f;
+            cut.setVoiceEnabled(p->idx_0, p->value > 0.f);
             break;
         case Commands::Id::SET_LEVEL_IN_CUT:
             inLevel[p->idx_0][p->idx_1].setTarget(p->value);
@@ -84,7 +84,7 @@ void SoftcutClient::handleCommand(Commands::CommandPacket *p) {
 
             //-- voice levels, pan
         case Commands::Id::SET_CUT_VOICE_PAN:
-            outPan[p->idx_0].setTarget((p->value / 2) + 0.5); // map -1,1 to 0,1
+            outPan[p->idx_0].setTarget((p->value * 0.5f) + 0.5f); // map -1,1 to 0,1
             break;
         case Commands::Id::SET_CUT_VOICE_LEVEL:
             outLevel[p->idx_0].setTarget(p->value);
@@ -183,8 +183,15 @@ void SoftcutClient::handleCommand(Commands::CommandPacket *p) {
         case Commands::Id::SET_CUT_VOICE_SYNC:
             cut.syncVoice(p->idx_0, p->idx_1, p->value);
             break;
-        case Commands::Id::SET_CUT_VOICE_DUCK_TARGET:
-            cut.voice(p->idx_0)->setDuckTarget(cut.voice(p->idx_1));
+        case Commands::Id::SET_CUT_VOICE_READ_DUCK_TARGET:
+            cut.voice(p->idx_0)->setReadDuckTarget(cut.voice(p->idx_1));
+            break;
+        case Commands::Id::SET_CUT_VOICE_WRITE_DUCK_TARGET:
+            cut.voice(p->idx_0)->setWriteDuckTarget(cut.voice(p->idx_1));
+            break;
+        case Commands::Id::SET_CUT_VOICE_FOLLOW_TARGET:
+            cut.voice(p->idx_0)->setFollowTarget(cut.voice(p->idx_1));
+            break;
         default:;;
     }
 }
@@ -192,20 +199,19 @@ void SoftcutClient::handleCommand(Commands::CommandPacket *p) {
 void SoftcutClient::reset() {
 
     for (int v = 0; v < NumVoices; ++v) {
+        cut.setVoiceEnabled(v, false);
         cut.voice(v)->setBuffer(buf[v % 2], BufFrames);
         outLevel[v].setTarget(0.f);
         outLevel->setTime(0.001);
         outPan[v].setTarget(0.5f);
         outPan->setTime(0.001);
 
-        enabled[v] = false;
-
         setPhaseQuant(v, 1.f);
         setPhaseOffset(v, 0.f);
 
-        for (int i = 0; i < 2; ++i) {
-            inLevel[i][v].setTime(0.001);
-            inLevel[i][v].setTarget(0.0);
+        for (auto & i : inLevel) {
+            i[v].setTime(0.001);
+            i[v].setTarget(0.0);
         }
 
         for (int w = 0; w < NumVoices; ++w) {
@@ -213,8 +219,8 @@ void SoftcutClient::reset() {
             fbLevel[v][w].setTarget(0.0);
         }
 
-        cut.voice(v)->setLoopStart(v * 2);
-        cut.voice(v)->setLoopEnd(v * 2 + 1);
+        cut.voice(v)->setLoopStart((float)v * 2);
+        cut.voice(v)->setLoopEnd((float)v * 2 + 1);
 
         output[v].clear();
         input[v].clear();

--- a/clients/softcut-jack-osc/src/SoftcutClient.h
+++ b/clients/softcut-jack-osc/src/SoftcutClient.h
@@ -30,21 +30,19 @@ namespace softcut_jack_osc {
         // processors
         softcut::Softcut<NumVoices> cut;
         // main buffer
-        float buf[2][BufFrames];
+        float buf[2][BufFrames]{};
         // buffer index for use with BufDiskWorker
-        int bufIdx[2];
+        int bufIdx[2]{};
         // busses
-        StereoBus mix;
-        MonoBus input[NumVoices];
-        MonoBus output[NumVoices];
+        StereoBus mix{};
+        MonoBus input[NumVoices]{};
+        MonoBus output[NumVoices]{};
         // levels
         LogRamp inLevel[2][NumVoices];
         LogRamp outLevel[NumVoices];
         LogRamp outPan[NumVoices];
         LogRamp fbLevel[NumVoices][NumVoices];
-        // enabled flags
-        bool enabled[NumVoices];
-        softcut::phase_t quantPhase[NumVoices];
+        softcut::phase_t quantPhase[NumVoices]{};
 
     private:
         void process(jack_nframes_t numFrames) override;

--- a/clients/softcut-jack-osc/src/main.cpp
+++ b/clients/softcut-jack-osc/src/main.cpp
@@ -32,6 +32,8 @@ int main() {
     sc->connectDacPorts();
 
     OscInterface::init(sc.get());
+    OscInterface::printServerMethods();
+
     BufDiskWorker::init(48000);
 
 

--- a/clients/softcut-nrt-test/src/Test.h
+++ b/clients/softcut-nrt-test/src/Test.h
@@ -24,7 +24,7 @@ public:
     size_t startMs{};
 
     Test() {
-        cut.setVoiceBuffer(0, buf.data(), bufSize);
+        cut.voice(0)->setBuffer(buf.data(), bufSize);
     }
 
     void writeOutputSoundfile(const std::string &path) {
@@ -78,7 +78,8 @@ public:
     }
 
     void performBlock(float* &src, float* &dst) {
-        cut.processBlock(0, src, dst, blockSize);
+        //FIXME
+        // cut.processBlock(0, src, dst, blockSize);
         testBuffers.update(cut, 0, blockSize);
         src += blockSize;
         dst += blockSize;

--- a/clients/softcut-nrt-test/src/TestRateSignChange.h
+++ b/clients/softcut-nrt-test/src/TestRateSignChange.h
@@ -15,23 +15,24 @@ class TestRateSignChange : public Test<numFrames, bufSize, blockSize> {
         super::loadInputSoundFile("octave-sines.wav");
         super::loadBufferSoundFile("octave-sines.wav");
         super::cut.setSampleRate(48000);
-        super::cut.setFadeTime(0, 0.05);
-        super::cut.setLoopStart(0, 0.1);
-        super::cut.setLoopEnd(0, 0.2);
-        super::cut.setLoopFlag(0, true);
-        super::cut.setPlayFlag(0, true);
 
-        super::cut.setPreFilterEnabled(0, false);
+        super::cut.voice(0).setFadeTime(0.05);
+        super::cut.voice(0).setLoopStart(0.1);
+        super::cut.voice(0).setLoopEnd(0.2);
+        super::cut.voice(0).setLoopFlag(true);
+        super::cut.voice(0).setPlayFlag(true);
 
-        super::cut.setRecFlag(0, true);
-        super::cut.setRecLevel(0, 1.0);
-        super::cut.setPreLevel(0, 0.75);
-        super::cut.setPosition(0, 0.1);
+        super::cut.voice(0).setPreFilterEnabled(false);
 
-        super::cut.setRateSlewTime(0, 0.0);
-        super::cut.setRate(0,  1.0);
-        super::cut.setRateSlewTime(0, 2.0);
-        super::cut.setRate(0, -1.0);
+        super::cut.voice(0).setRecFlag(true);
+        super::cut.voice(0).setRecLevel(1.0);
+        super::cut.voice(0).setPreLevel(0.75);
+        super::cut.voice(0).setPosition(0.1);
+
+        super::cut.voice(0).setRateSlewTime(0.0);
+        super::cut.voice(0).setRate(1.0);
+        super::cut.voice(0).setRateSlewTime(2.0);
+        super::cut.voice(0).setRate(-1.0);
 
 
     }

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -52,9 +52,6 @@ namespace softcut {
         bool loopFlag{false};       // set to loop, unset for 1-shot
         int recOffsetSamples{-8}; // record offset from write head
 
-        frame_t fadeOutFrameBeforeLoop{};
-        frame_t fadeOutFrameAfterLoop{};
-
         //--- buffered state variables
         // rate, in per-sample position increment (1 == normal)
         SubHead::StateBuffer<rate_t> rate{1.f};
@@ -79,6 +76,7 @@ namespace softcut {
         void performSubheadReads(float *output, size_t numFrames);
 
         void updateSubheadPositions(size_t numFrames);
+        void copySubheadPositions(const ReadWriteHead &other, size_t numFrames);
 
         void updateSubheadWriteLevels(size_t numFrames);
 
@@ -106,8 +104,6 @@ namespace softcut {
         phase_t getActivePhase() const;
 
         phase_t wrapPhaseToLoop(phase_t p);
-
-//        frame_t wrapFrameToLoopFade(frame_t w);
 
         static constexpr size_t maxBlockSize = SubHead::maxBlockSize;
 

--- a/softcut-lib/include/softcut/Softcut.h
+++ b/softcut-lib/include/softcut/Softcut.h
@@ -5,8 +5,10 @@
 #ifndef Softcut_Softcut_H
 #define Softcut_Softcut_H
 
+#include <array>
 #include <memory>
 #include <thread>
+
 #include "Types.h"
 #include "Voice.h"
 
@@ -18,7 +20,13 @@ namespace softcut {
         friend class TestBuffers;
 
     private:
-        Voice scv[numVoices];
+        std::array<Voice, numVoices> voices;
+        // enabled flags
+        std::array<bool, numVoices> voiceEnabled;
+        // input and output busses are assigned and persisted
+        std::array<float*, numVoices> input;
+        std::array<float*, numVoices> output;
+
     public:
 
         Softcut() {
@@ -26,32 +34,42 @@ namespace softcut {
         }
 
         void reset() {
-            for (int v = 0; v < numVoices; ++v) {
-                scv[v].reset();
+            for (int i=0; i<numVoices; ++i) {
+                voices[i].reset();
                 /// test: set each voice to duck the next one, in a loop
-                scv[v].setDuckTarget( &(scv[(v+1)%numVoices]) );
-                // test: set voices to duck each other in pairs
-                //// (FIXME: probably won't work right because each voice processes whole block in turn...)
-//                scv[0].setDuckTarget(&(scv[1]));
-//                scv[1].setDuckTarget(&(scv[0]));
+                voices[i].setReadDuckTarget(&(voices[(i + 1) % numVoices]) );
             };
 
         }
 
-        // assumption: v is in range
-        void processBlock(int v, float *in, float *out, int numFrames) {
-            scv[v].processBlockMono(in, out, numFrames);
+        void processBlock(int numFrames) {
+            for (int i=0; i<numVoices; ++i) {
+                if (voiceEnabled[i]) {
+                    voices[i].updatePositions(numFrames);
+                    voices[i].updateQuantPhase();
+                }
+            }
+            for (int i=0; i<numVoices; ++i) {
+                if (voiceEnabled[i]) {
+                    voices[i].performReads(output[i], numFrames);
+                }
+            }
+            for (int i=0; i<numVoices; ++i) {
+                if (voiceEnabled[i]) {
+                    voices[i].performWrites(input[i], numFrames);
+                }
+            }
         }
 
         void setSampleRate(unsigned int hz) {
-            for (auto &v : scv) {
+            for (auto &v : voices) {
                 v.setSampleRate(hz);
             }
         }
 
         Voice *voice(int i) {
             if (i >= 0 && i < numVoices) {
-                return &(scv[i]);
+                return &(voices[i]);
             } else {
                 return nullptr;
             }
@@ -59,10 +77,22 @@ namespace softcut {
 
 
         void syncVoice(int follower, int leader, float offset) {
-            // TODO
+            voices[follower].syncPosition(voices[leader], offset);
         }
+
+
+        void setInputBus( int vIdx, float* src) {
+            input[vIdx] = src;
+        }
+        void setOutputBus(int vIdx, float* dst) {
+            output[vIdx] = dst;
+        }
+        void setVoiceEnabled(int vIdx, bool val) {
+            voiceEnabled[vIdx] = val;
+        }
+
     };
 }
 
 
-#endif //Softcut_Softcut_H2
+#endif //Softcut_Softcut_H

--- a/softcut-lib/include/softcut/TestBuffers.h
+++ b/softcut-lib/include/softcut/TestBuffers.h
@@ -65,7 +65,7 @@ namespace softcut {
 
         template<int N>
         void update(Softcut <N> &cut, int voiceId, size_t numFrames) {
-            update(cut.scv[voiceId].rwh, numFrames);
+            update(cut.voices[voiceId].rwh, numFrames);
         }
 
         void update(const ReadWriteHead &rwh, size_t numFrames) {


### PR DESCRIPTION
several improvements here related to duck/follow modes. many still need close testing.

- read ducking now doesn't apply to subheads that are playing but silent (fade level near zero.)

- write ducking is enabled (not tested). unlike read-ducking, this is a destructive operation (producing soft gaps in the buffer), but allows two voices to simultaneously record/preserve in the same buffer region without clicks.

- both read- and write-ducking can be performed cyclically (two voices ducking each other.) each voice can still only have one read-duck and one write-duck target; this limitation is unlikely to change.

- "follow" mode is enabled, wherein a voice copies all its state data from another voice on each block (presumably with different input mix and target buffer.) this is not really tested at all yet.

- re-enabled "sync voice"  command and quantized phase reports

-----------

also, some random general cleanups, and updated `dsp-kit` version.
-------

BTW: the NRT testing client is stale now, and needs a little work if we want full post-mortem exams of buffered voice states.