### PR TITLE
Include /usr/local/include when building on macOS

### DIFF
--- a/softcut-lib/CMakeLists.txt
+++ b/softcut-lib/CMakeLists.txt
@@ -12,4 +12,8 @@ set(SRC
 
 include_directories(include src)
 
+if(APPLE)
+    include_directories(/usr/local/include)
+endif()
+
 add_library(softcut STATIC ${SRC})


### PR DESCRIPTION
I am attempting to build crone on macOS and I am getting some errors when building softcut due to boost not being included. I noticed that in crone, boost is explicitly included with `include_directories(/usr/local/include)` for macOS, so I added that here as well.

There are some errors in the crone project as well, so my plan is to submit a PR to the main norns repo and update the softcut submodule to this commit in that PR.