### PR TITLE
reset the record offset in samples on Voice::reset()

### DIFF
--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -39,6 +39,7 @@ void Voice::reset() {
 
     setRecPreSlewTime(0.001);
     setRateSlewTime(0.001);
+    sch.setRecOffsetSamples(-8);
 
     recFlag = false;
     playFlag = false;


### PR DESCRIPTION
ensure that record offset value is sane on voice reset.