### PR TITLE
reset rate

### DIFF
--- a/softcut-lib/include/softcut/Utilities.h
+++ b/softcut-lib/include/softcut/Utilities.h
@@ -181,8 +181,13 @@ namespace softcut {
             return this->update();
         }
 
-        float getTarget() {
+        float getTarget() const {
             return x0;
+        }
+
+        void reset(float x) {
+            x0 = x;
+            y0 = x;
         }
 
     };

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -37,8 +37,10 @@ void Voice::reset() {
     svfPost.setFc(12000);
     svfPostDryLevel = 1.0;
 
+    rateRamp.reset(1.0);
     setRecPreSlewTime(0.001);
     setRateSlewTime(0.001);
+
     sch.setRecOffsetSamples(-8);
 
     recFlag = false;

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -38,6 +38,9 @@ void Voice::reset() {
     svfPostDryLevel = 1.0;
 
     rateRamp.reset(1.0);
+    recRamp.reset(0.0);
+    preRamp.reset(0.0);
+    
     setRecPreSlewTime(0.001);
     setRateSlewTime(0.001);
 


### PR DESCRIPTION
`Voice::reset()` now also sets ramped parameters (rate, rec, pre)

added `reset` method to log interpolator to facilitate this