### PR TITLE
fix pingpong logic again

### DIFF
--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -30,7 +30,7 @@ namespace softcut {
         phase_t requestedPosition = -1.0;
         frame_t lastFrameIdx; // last used index into processing block
 
-       void handlePhaseResult(frame_t fr, const SubHead::PhaseResult *res);
+       void handlePhaseResult(frame_t fr_1, frame_t fr, const SubHead::PhaseResult *res);
 //       void setLoop(int headIdx, frame_t fr, phase_t pos);
         // attempt to perform any pending position change requests
         // return the index of the subhead that just became active,

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -74,6 +74,8 @@ void ReadWriteHead::handlePhaseResult(frame_t fr_1, frame_t fr, const SubHead::P
                     }
                     head[k].setPosition(fr, end);
                 } else {
+                    // FIXME: maybe there is a better way than writing this every sample.
+                    head[k].rateDirMul[fr] = 1.0;
                     head[k].setPosition(fr, start);
                 }
                 head[k].playState[fr] = SubHead::PlayState::FadeIn;
@@ -93,6 +95,8 @@ void ReadWriteHead::handlePhaseResult(frame_t fr_1, frame_t fr, const SubHead::P
                     }
                     head[k].setPosition(fr, start);
                 } else {
+                    // FIXME: maybe there is a better way than writing this every sample.
+                    head[k].rateDirMul[fr] = 1.0;
                     head[k].setPosition(fr, end);
                 }
                 head[k].playState[fr] = SubHead::PlayState::FadeIn;

--- a/softcut-lib/src/SubHead.cpp
+++ b/softcut-lib/src/SubHead.cpp
@@ -47,7 +47,8 @@ void SubHead::setPosition(frame_t i, phase_t position) {
 
 void SubHead::syncWrIdx(frame_t i) {
     frame_t off = rwh->recOffsetSamples;
-    off *= rateSign[i];
+    //off *= rateSign[i];
+    off *= static_cast<frame_t>(rateDirMul[i] * rwh->rate[i]);
     auto f = static_cast<frame_t>(phase[i] + off);
     wrIdx[i] = wrapBufIndex(f);
 }


### PR DESCRIPTION
pingpong logic was still wrong. two commits:

1. 
- was flipping the sign of the newly active subhead, instead of making sign of new head the inverse of sign of current head. (in practice: during pingpong looping, one subhead will always be going backwards, the other forwards. but whatever, we'll set them explicitly on each loop.)
- was reading direction state from current frame (write target), rather than previous frame (from which the last phase update was calculated.)

changing these fixes, for me, the weird thing where fade time was effectively added to loop time. 

2. 
when exiting pingpong mode, the directions of the subheads were not being updated. this meant that one would always be going backwards compared to the current rate, making things all weird. now the direction is just set on every loop frame, regardless of loop mode.

