### PR TITLE
fix sign mistake in rec curve calculation

### DIFF
--- a/softcut-lib/src/FadeCurves.cpp
+++ b/softcut-lib/src/FadeCurves.cpp
@@ -75,7 +75,7 @@ void FadeCurves::calcRecFade() {
             buf[i++] = y;
         }
         while (i < n) {
-            y = sinf(x);
+            y = sinf(x) * -1.f;
             buf[i++] = y;
             x += phi;
         }
@@ -83,6 +83,7 @@ void FadeCurves::calcRecFade() {
     } else {
         BOOST_ASSERT_MSG(false, "undefined fade shape");
     }
+
     memcpy(recFadeBuf, buf, fadeBufSize*sizeof(float));
 }
 


### PR DESCRIPTION
this little math error was causing live buffer input to have its sign inverted. whoops!