### PR TITLE
toggle running/stopped state as appropriate when setting play/rec flags

### DIFF
--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -26,21 +26,30 @@ namespace softcut {
         void setSampleRate(float sr);
         void setBuffer(sample_t *buf, uint32_t size);
         void setRate(rate_t x);
+
+	// set loop (region) start point in seconds
         void setLoopStartSeconds(float x);
+	// set loop (region) end point in seconds
         void setLoopEndSeconds(float x);
         void setFadeTime(float secs);
         void setLoopFlag(bool val);
+
+	// set amplitudes
         void setRec(float x);
         void setPre(float x);
+
+	// enqueue a position change with crossfade
         void cutToPos(float seconds);
+
+	// immediately put both subheads in stopped state
+	void stop();
+	// immediately start playing  from current position (no fadein)
+	void run();
 
         void setRecOffsetSamples(int d);
 
         phase_t getActivePhase();
         rate_t getRate();
-	// immediately put both subheads in stopped state
-	void stop();
-
     protected:
         friend class SubHead;
 

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -212,3 +212,7 @@ void ReadWriteHead::stop() {
     head[0].setState(State::Stopped);
     head[1].setState(State::Stopped);
 }
+
+void ReadWriteHead::run() {
+    head[active].setState(State::Playing);
+}

--- a/softcut-lib/src/SubHead.cpp
+++ b/softcut-lib/src/SubHead.cpp
@@ -189,6 +189,9 @@ void SubHead::setState(State state) {
     if (state_ == Stopped) {
 	fade_ = 0.f;
     }
+    if (state == Playing) {
+	fade_ = 1.f;
+    }
 }
 
 void SubHead::setRecOffsetSamples(int d) {

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -134,11 +134,28 @@ void Voice::setPreLevel(float amp) {
 }
 
 void Voice::setRecFlag(bool val) {
+    if (recFlag) {
+	if (!(val || playFlag)) {
+	    sch.stop();
+	}
+    } else {
+	if (val && !playFlag) {
+	    sch.run();
+	}
+    }
     recFlag = val;
 }
 
-
 void Voice::setPlayFlag(bool val) {
+    if (playFlag) {
+	if (!(val || recFlag)) {
+	    sch.stop();
+	}
+    } else {
+	if (val && !recFlag) {
+	    sch.run();
+	}
+    }
     playFlag = val;
 }
 


### PR DESCRIPTION
this makes for less surprising behavior when toggling play/rec dynamically:

- when (not (rec or play)) becomes true, immediately enter "stopped" state
- when (rec or play) becomes true, immediately enter "playing" state

this means `rec` and/or `play` flags can be used to perform a hard stop/start, and repositioning can be done in between without producing unexpected crossfades.

----

in most cases, it's still probably more useful to simply set the levels and positions, not caring about where the phase ends up. in a future (breaking) version it would be nice to revise the whole interface and add things like "fade out and stop" that users might reasonably expect.