### PR TITLE
command to "stop recording at end of loop+fade"

### DIFF
--- a/clients/softcut_jack_osc/src/OscInterface.cpp
+++ b/clients/softcut_jack_osc/src/OscInterface.cpp
@@ -209,9 +209,9 @@ void OscInterface::addServerMethods() {
         Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_FLAG, argv[0]->i, argv[1]->f);
     });
 
-    addServerMethod("/set/param/cut/rec_once_flag", "if", [](lo_arg **argv, int argc) {
-        if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_ONCE_FLAG, argv[0]->i, argv[1]->f);
+    addServerMethod("/set/param/cut/rec_once_flag", "iif", [](lo_arg **argv, int argc) {
+        if (argc < 3) { return; }
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_ONCE_FLAG, argv[0]->i, argv[1]->i, argv[2]->f);
     });
 
     addServerMethod("/set/param/cut/play_flag", "if", [](lo_arg **argv, int argc) {

--- a/clients/softcut_jack_osc/src/OscInterface.cpp
+++ b/clients/softcut_jack_osc/src/OscInterface.cpp
@@ -209,6 +209,11 @@ void OscInterface::addServerMethods() {
         Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_FLAG, argv[0]->i, argv[1]->f);
     });
 
+    addServerMethod("/set/param/cut/rec_once_flag", "if", [](lo_arg **argv, int argc) {
+        if (argc < 2) { return; }
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_ONCE_FLAG, argv[0]->i, argv[1]->f);
+    });
+
     addServerMethod("/set/param/cut/play_flag", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PLAY_FLAG, argv[0]->i, argv[1]->f);

--- a/clients/softcut_jack_osc/src/OscInterface.cpp
+++ b/clients/softcut_jack_osc/src/OscInterface.cpp
@@ -209,9 +209,9 @@ void OscInterface::addServerMethods() {
         Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_FLAG, argv[0]->i, argv[1]->f);
     });
 
-    addServerMethod("/set/param/cut/rec_once_flag", "iif", [](lo_arg **argv, int argc) {
-        if (argc < 3) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_ONCE_FLAG, argv[0]->i, argv[1]->i, argv[2]->f);
+    addServerMethod("/set/param/cut/rec_once", "if", [](lo_arg **argv, int argc) {
+        if (argc < 2) { return; }
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_ONCE, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/play_flag", "if", [](lo_arg **argv, int argc) {

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -82,6 +82,9 @@ namespace softcut {
         float pre;      // pre-record level
         float rec;      // record level
         bool recOnceFlag; // set to record once
+        bool recOnceActive;
+        bool recOnceDone;
+        int recOnceHead;
 
         rate_t rate;    // current rate
         TestBuffers testBuf;

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -34,6 +34,7 @@ namespace softcut {
         void setFadeTime(float secs);
         void setLoopFlag(bool val);
         void setRecOnceFlag(bool val);
+        bool getRecOnceDone();
 
 	// set amplitudes
         void setRec(float x);
@@ -81,10 +82,9 @@ namespace softcut {
         bool loopFlag;      // set to loop, unset for 1-shot
         float pre;      // pre-record level
         float rec;      // record level
-        bool recOnceFlag; // set to record once
-        bool recOnceActive;
-        bool recOnceDone;
-        int recOnceHead;
+        bool recOnceFlag; // set to record one full loop
+        bool recOnceDone; // triggers done to tell voice to unset rec flag
+        int recOnceHead; // keeps track of which subhead is writing
 
         rate_t rate;    // current rate
         TestBuffers testBuf;

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -35,6 +35,7 @@ namespace softcut {
         void setLoopFlag(bool val);
         void setRecOnceFlag(bool val);
         bool getRecOnceDone();
+        bool getRecOnceActive();
 
 	// set amplitudes
         void setRec(float x);

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -33,6 +33,7 @@ namespace softcut {
         void setLoopEndSeconds(float x);
         void setFadeTime(float secs);
         void setLoopFlag(bool val);
+        void setRecOnceFlag(bool val);
 
 	// set amplitudes
         void setRec(float x);
@@ -80,6 +81,7 @@ namespace softcut {
         bool loopFlag;      // set to loop, unset for 1-shot
         float pre;      // pre-record level
         float rec;      // record level
+        bool recOnceFlag; // set to record once
 
         rate_t rate;    // current rate
         TestBuffers testBuf;

--- a/softcut-lib/include/softcut/Softcut.h
+++ b/softcut-lib/include/softcut/Softcut.h
@@ -69,6 +69,10 @@ namespace softcut {
             scv[voice].setRecFlag(val);
         }
 
+        void setRecOnceFlag(int voice, bool val) {
+            scv[voice].setRecOnceFlag(val);
+        }
+
         void setPlayFlag(int voice, bool val) {
             scv[voice].setPlayFlag(val);
         }

--- a/softcut-lib/include/softcut/Voice.h
+++ b/softcut-lib/include/softcut/Voice.h
@@ -95,8 +95,6 @@ namespace softcut {
 
         bool getRecFlag();
 
-        bool getRecOnceFlag();
-
 	float getActivePosition();
 
 	// use this from non-audio threads

--- a/softcut-lib/include/softcut/Voice.h
+++ b/softcut-lib/include/softcut/Voice.h
@@ -87,11 +87,15 @@ namespace softcut {
 
         void setPhaseOffset(float x);
 
+        void setRecOnce(bool val);
+
         phase_t getQuantPhase();
 
         bool getPlayFlag();
 
         bool getRecFlag();
+
+        bool getRecOnceFlag();
 
 	float getActivePosition();
 
@@ -150,6 +154,7 @@ namespace softcut {
 
         bool playFlag;
         bool recFlag;
+        bool recOnceFlag;
 
     };
 }

--- a/softcut-lib/include/softcut/Voice.h
+++ b/softcut-lib/include/softcut/Voice.h
@@ -154,7 +154,6 @@ namespace softcut {
 
         bool playFlag;
         bool recFlag;
-        bool recOnceFlag;
 
     };
 }

--- a/softcut-lib/include/softcut/Voice.h
+++ b/softcut-lib/include/softcut/Voice.h
@@ -40,6 +40,8 @@ namespace softcut {
 
         void setRecFlag(bool val);
 
+        void setRecOnceFlag(bool val);
+
         void setPlayFlag(bool val);
 
         void setPreFilterFc(float);
@@ -86,8 +88,6 @@ namespace softcut {
         void setPhaseQuant(float x);
 
         void setPhaseOffset(float x);
-
-        void setRecOnce(bool val);
 
         phase_t getQuantPhase();
 

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -200,6 +200,10 @@ bool ReadWriteHead::getRecOnceDone() {
   return recOnceDone;
 }
 
+bool ReadWriteHead::getRecOnceActive() {
+  return (recOnceDone || recOnceFlag || recOnceHead>-1);
+}
+
 void ReadWriteHead::setSampleRate(float sr_) {
     sr = sr_;
     head[0].setSampleRate(sr);

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -33,7 +33,7 @@ void ReadWriteHead::processSample(sample_t in, sample_t *out) {
 
     BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
 
-    if (recOnceDone || (recOnceHead > -1)) {
+    if (recOnceFlag || recOnceDone || (recOnceHead > -1)) {
         if (recOnceHead > -1) {
             head[recOnceHead].poke(in, pre, rec);
         }
@@ -56,7 +56,7 @@ void ReadWriteHead::processSampleNoRead(sample_t in, sample_t *out) {
 
     BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
 
-    if (recOnceDone || (recOnceHead > -1)) {
+    if (recOnceFlag || recOnceDone || (recOnceHead > -1)) {
         if (recOnceHead > -1) {
             head[recOnceHead].poke(in, pre, rec);
         }

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -168,6 +168,10 @@ void ReadWriteHead::setLoopFlag(bool val) {
     loopFlag = val;
 }
 
+void ReadWriteHead::setRecOnceFlag(bool val) {
+    recOnceFlag = val;
+}
+
 void ReadWriteHead::setSampleRate(float sr_) {
     sr = sr_;
     head[0].setSampleRate(sr);

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -235,7 +235,7 @@ void Voice::setPostFilterDry(float x) {
 }
 
 void Voice::setRecOnce(bool val) {
-    recOnceFlag = val;
+    sch.setRecOnceFlag(val);
 }
 
 void Voice::setBuffer(float *b, unsigned int nf) {

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -97,7 +97,7 @@ void Voice:: processBlockMono(const float *in, float *out, int numFrames) {
         if (sch.getRecOnceDone()) {
             // record once is finished, turn off recording flag
             // and reset the recording subheads
-            setRecFlag(false);
+	    recFlag = false;
             sch.setRecOnceFlag(false);
         }
     }
@@ -153,6 +153,12 @@ void Voice::setRecFlag(bool val) {
 	}
     }
     recFlag = val;
+    if (!val) {
+	// turn off rec once if active
+        if (sch.getRecOnceActive()) {
+	    setLoopFlag(false);
+	}
+    }
 }
 
 void Voice::setPlayFlag(bool val) {

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -92,6 +92,15 @@ void Voice:: processBlockMono(const float *in, float *out, int numFrames) {
 
     
     rawPhase.store(sch.getActivePhase(), std::memory_order_relaxed);
+
+    if(recFlag) {
+        if (sch.getRecOnceDone()) {
+            // record once is finished, turn off recording flag
+            // and reset the recording subheads
+            setRecFlag(false);
+            sch.setRecOnceFlag(false);
+        }
+    }
 }
 
 void Voice::setSampleRate(float hz) {
@@ -235,6 +244,9 @@ void Voice::setPostFilterDry(float x) {
 
 void Voice::setRecOnceFlag(bool val) {
     sch.setRecOnceFlag(val);
+    if (val) {
+        setRecFlag(true);
+    }
 }
 
 void Voice::setBuffer(float *b, unsigned int nf) {

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -49,7 +49,6 @@ void Voice::reset() {
 
     recFlag = false;
     playFlag = false;
-    recOnceFlag = false;
 
     sch.init(&fadeCurves);
 }
@@ -285,10 +284,6 @@ bool Voice::getPlayFlag() {
 
 bool Voice::getRecFlag() {
     return recFlag;
-}
-
-bool Voice::getRecOnceFlag() {
-    return recOnceFlag;
 }
 
 float Voice::getActivePosition() {

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -49,6 +49,7 @@ void Voice::reset() {
 
     recFlag = false;
     playFlag = false;
+    recOnceFlag = false;
 
     sch.init(&fadeCurves);
 }
@@ -163,6 +164,10 @@ void Voice::setLoopFlag(bool val) {
     sch.setLoopFlag(val);
 }
 
+void Voice::setLoopFlag(bool val) {
+    sch.setLoopFlag(val);
+}
+
 // input filter
 void Voice::setPreFilterFc(float x) {
     svfPreFcBase = x;
@@ -233,6 +238,10 @@ void Voice::setPostFilterDry(float x) {
     svfPostDryLevel = x;
 }
 
+void Voice::setRecOnce(bool val) {
+    recOnceFlag = val;
+}
+
 void Voice::setBuffer(float *b, unsigned int nf) {
     buf = b;
     bufFrames = nf;
@@ -280,6 +289,10 @@ bool Voice::getPlayFlag() {
 
 bool Voice::getRecFlag() {
     return recFlag;
+}
+
+bool Voice::getRecOnceFlag() {
+    return recOnceFlag;
 }
 
 float Voice::getActivePosition() {

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -233,7 +233,7 @@ void Voice::setPostFilterDry(float x) {
     svfPostDryLevel = x;
 }
 
-void Voice::setRecOnce(bool val) {
+void Voice::setRecOnceFlag(bool val) {
     sch.setRecOnceFlag(val);
 }
 

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -164,10 +164,6 @@ void Voice::setLoopFlag(bool val) {
     sch.setLoopFlag(val);
 }
 
-void Voice::setLoopFlag(bool val) {
-    sch.setLoopFlag(val);
-}
-
 // input filter
 void Voice::setPreFilterFc(float x) {
     svfPreFcBase = x;


### PR DESCRIPTION
here I'm introducing a new command called (`softcut.rec_once`) (addressing https://github.com/monome/softcut-lib/issues/39) that when enabled will tell the softcut voice to continue recording until a position change, at which point the new subhead stops writing and the old subhead continues to write (while fading out), after which no writing takes place. this allows you to make single-loop recordings with crossfades.

to make this work, I had to modify `ReadWriteHead` in a way that allows it to have only *one* active writing subhead (normally it always has two, or none), so I added some flags to control the behavior. the implementation makes the API a little wonky:

- since its updated at the first position change, one way to use this would necessitate running `softcut.position(<voice>,loop_start)` immediately after setting the `rec_once` flag so that position change to the beginning would start the recording. that seems okay maybe? otherwise it will automatically be activated next time the loop crosses the threshold.
- to record *again* after using `rec_once(<voice>,1)`, the flag for recording once needs to be reset. i.e. you would have to run `softcut.rec_once(<voice>,0)` otherwise the write heads will continue to be non-recording after the record once behavior has been activated.


I'm open to any improvements and changes I can make to help make this better.


### testing 

this PR goes along with this branch of norns: https://github.com/monome/norns/pull/1494

testing procedure (if there is a better way please let me know!):

```
# get everything
cd ~/norns
git remote set-url origin https://github.com:schollz/norns.git
git pull
git checkout sc-rec-once
cd ~/norns/crone/softcut/softcut-lib
git remote set-url origin https://github.com:schollz/softcut-lib.git
git pull 
git checkout rec-once
# compile everything
cd ~/norns/crone/softcut/softcut-lib && ./waf && cd ~/norns && ./waf
# restart norns
sudo systemctl restart norns-jack.service; sudo systemctl restart norns-matron.service; sudo systemctl restart norns-crone.service
```
for testing, I used this script (modified study 4). it results in audio files (`/home/we/dust/audio/rec_once_[1|2|3|4].wav`) which should show a single loop with crossfades extending past the loop point based on `fade_time`.

```lua
-- softcut.rec_once test

rate = 1.0
rec = 1.0
pre = 0.0

function init()
	audio.level_adc_cut(1)
  softcut.buffer_clear()
  softcut.enable(1,1)
  softcut.recpre_slew_time(1,0)
  softcut.fade_time(1,0.5)
  softcut.buffer(1,1)
  softcut.level(1,1.0)
  softcut.rate(1,1.0)
  softcut.loop(1,1)
  softcut.loop_start(1,1)
  softcut.loop_end(1,2)
  softcut.position(1,1)
  softcut.play(1,1)
  softcut.level_input_cut(1,1,1.0)
  softcut.level_input_cut(2,1,1.0)
  softcut.rec_level(1,rec)
  softcut.pre_level(1,pre)

  -- async test
  clock.run(function()
    -- give it some time to initiate seems nessecary to avoid a dropout in the beginning
    print("initiating tests")
    clock.sleep(1)
    -- initiates voice 1 to recording a loop starting at position 1
    softcut.rec_once(1,1)
    clock.sleep(2.5)
    softcut.buffer_write_mono("/home/we/dust/audio/rec_once_1.wav",0,4)
    print("wrote /home/we/dust/audio/rec_once_1.wav")
    clock.sleep(1)

     -- initiates voice 1 to recording a loop starting at position 1.5
    softcut.rec_once(1,1.5)
    clock.sleep(2)
    softcut.buffer_write_mono("/home/we/dust/audio/rec_once_2.wav",0,4)
    print("wrote /home/we/dust/audio/rec_once_2.wav")
    clock.sleep(1)
    
    -- this would normally erase but the recording is stopped
    softcut.rec_level(1,0) 
    softcut.pre_level(1,0)
    clock.sleep(1.5)
    softcut.buffer_write_mono("/home/we/dust/audio/rec_once_3.wav",0,4)
    print("wrote /home/we/dust/audio/rec_once_3.wav (should be same as 2)")
    clock.sleep(1)

    print("overdubbing when it crosses again - this should be synced with 2 and 3")
    softcut.rec_level(1,0.5) 
    softcut.pre_level(1,1)
     -- initiates voice 1 to recording a loop starting at next cross
    softcut.rec_once(1)
    clock.sleep(2.5)
    softcut.buffer_write_mono("/home/we/dust/audio/rec_once_4.wav",0,4)
    print("wrote /home/we/dust/audio/rec_once_4.wav")

  end)
  
end

function enc(n,d)
  if n==1 then
    rate = util.clamp(rate+d/100,-4,4)
    softcut.rate(1,rate)
  elseif n==2 then
    rec = util.clamp(rec+d/100,0,1)
    softcut.rec_level(1,rec)
  elseif n==3 then
    pre = util.clamp(pre+d/100,0,1)
    softcut.pre_level(1,pre)
  end
  redraw()
end

function key(n,z)
  if z==1 then
    clock.run(function()
      print("overdubbing")
      softcut.pre_level(1,0)
      softcut.rec_once(1,1)
      clock.sleep(4)
      softcut.buffer_write_mono("/home/we/dust/audio/rec_once_4.wav",0,4)
      print("wrote /home/we/dust/audio/rec_once_4.wav")
    end)
  end
  redraw()
end

function redraw()
  screen.clear()
  screen.move(10,30)
  screen.text("rate: ")
  screen.move(118,30)
  screen.text_right(string.format("%.2f",rate))
  screen.move(10,40)
  screen.text("rec: ")
  screen.move(118,40)
  screen.text_right(string.format("%.2f",rec))
  screen.move(10,50)
  screen.text("pre: ")
  screen.move(118,50)
  screen.text_right(string.format("%.2f",pre))
  screen.update()
end
```