### PR TITLE
add interpolation mode & resampling bypass commands

### DIFF
--- a/clients/softcut_jack_osc/src/OscInterface.cpp
+++ b/clients/softcut_jack_osc/src/OscInterface.cpp
@@ -307,6 +307,11 @@ void OscInterface::addServerMethods() {
         if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_DRY, argv[0]->i, argv[1]->f);
     });
+    
+    addServerMethod("/set/param/cut/interpolation", "ii", [](lo_arg **argv, int argc) {
+        if (argc < 2) { return; }
+        Commands::softcutCommands.post(Commands::Id::SET_CUT_INTERPOLATION, argv[0]->i, argv[1]->i);
+    });
 
     addServerMethod("/set/param/cut/voice_sync", "iif", [](lo_arg **argv, int argc) {
         if (argc < 3) { return; }

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -42,7 +42,7 @@ namespace softcut {
         void setPre(float x);
 
     // set interpolation
-        void setInterpolation(int mode)
+        void setInterpolation(int mode);
 
 	// enqueue a position change with crossfade
         void cutToPos(float seconds);

--- a/softcut-lib/include/softcut/ReadWriteHead.h
+++ b/softcut-lib/include/softcut/ReadWriteHead.h
@@ -41,6 +41,9 @@ namespace softcut {
         void setRec(float x);
         void setPre(float x);
 
+    // set interpolation
+        void setInterpolation(int mode)
+
 	// enqueue a position change with crossfade
         void cutToPos(float seconds);
 

--- a/softcut-lib/include/softcut/Resampler.h
+++ b/softcut-lib/include/softcut/Resampler.h
@@ -17,7 +17,7 @@
 
 // uncomment to use linear interpolation. honestly can't hear a huge difference?
 // FIXME: should be template param i guess
-#define RESAMPLER_INTERPOLATE_LINEAR
+//#define RESAMPLER_INTERPOLATE_LINEAR
 
 namespace softcut {
 

--- a/softcut-lib/include/softcut/Resampler.h
+++ b/softcut-lib/include/softcut/Resampler.h
@@ -36,7 +36,7 @@ namespace softcut {
             INTERPOLATE_ZERO = 1,
             INTERPOLATE_LINEAR = 2,
             INTERPOLATE_CUBIC = 4
-        }
+        };
 
         // constructor
         Resampler() : rate_(1.0), phi_(1.0), phase_(0.0), mode_(INTERPOLATE_CUBIC)
@@ -56,7 +56,7 @@ namespace softcut {
         }
 
         void setInterpolationMode(int mode) {
-            mode_ = mode
+            mode_ = mode;
         }
 
         void setRate(rate_t r) {

--- a/softcut-lib/include/softcut/Resampler.h
+++ b/softcut-lib/include/softcut/Resampler.h
@@ -17,7 +17,7 @@
 
 // uncomment to use linear interpolation. honestly can't hear a huge difference?
 // FIXME: should be template param i guess
-// #define RESAMPLER_INTERPOLATE_LINEAR
+#define RESAMPLER_INTERPOLATE_LINEAR
 
 namespace softcut {
 

--- a/softcut-lib/include/softcut/Softcut.h
+++ b/softcut-lib/include/softcut/Softcut.h
@@ -181,6 +181,10 @@ namespace softcut {
             scv[follow].cutToPos(scv[lead].getActivePosition() + offset);
         }
 
+        void setInterpolation(int id, int interpolationMode) {
+            scv[id].setInterpolation(interpolationMode)
+        }
+
         void setVoiceBuffer(int id, float *buf, size_t bufFrames) {
             scv[id].setBuffer(buf, bufFrames);
         }

--- a/softcut-lib/include/softcut/Softcut.h
+++ b/softcut-lib/include/softcut/Softcut.h
@@ -182,7 +182,7 @@ namespace softcut {
         }
 
         void setInterpolation(int id, int interpolationMode) {
-            scv[id].setInterpolation(interpolationMode)
+            scv[id].setInterpolation(interpolationMode);
         }
 
         void setVoiceBuffer(int id, float *buf, size_t bufFrames) {

--- a/softcut-lib/include/softcut/SubHead.h
+++ b/softcut-lib/include/softcut/SubHead.h
@@ -31,7 +31,7 @@ namespace softcut {
             INTERPOLATE_ZERO = 1,
             INTERPOLATE_LINEAR = 2,
             INTERPOLATE_CUBIC = 4
-        }
+        };
 
     private:
         sample_t peek4();

--- a/softcut-lib/include/softcut/SubHead.h
+++ b/softcut-lib/include/softcut/SubHead.h
@@ -35,6 +35,8 @@ namespace softcut {
 
     private:
         sample_t peek4();
+        sample_t peek2();
+        sample_t peek1();
         unsigned int wrapBufIndex(int x);
 
         void pokeResampling(int nframes);

--- a/softcut-lib/include/softcut/SubHead.h
+++ b/softcut-lib/include/softcut/SubHead.h
@@ -25,6 +25,13 @@ namespace softcut {
     public:
         void init(FadeCurves *fc);
         void setSampleRate(float sr);
+    
+        enum {
+            INTERPOLATE_ZERO_NO_RESAMPLE = 0,
+            INTERPOLATE_ZERO = 1,
+            INTERPOLATE_LINEAR = 2,
+            INTERPOLATE_CUBIC = 4
+        }
 
     private:
         sample_t peek4();
@@ -51,6 +58,8 @@ namespace softcut {
         void setState(State state);
         void setPhase(phase_t phase);
 
+        void setInterpolation(int mode);
+
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // **NB** buffer size must be a power of two!!!!
         void setBuffer(sample_t *buf, unsigned int frames);
@@ -65,6 +74,8 @@ namespace softcut {
         unsigned int wrIdx_; // write index
         unsigned int bufFrames_;
         unsigned int bufMask_;
+
+        int interpolationMode_;
 
         State state_;
         rate_t rate_;

--- a/softcut-lib/include/softcut/SubHead.h
+++ b/softcut-lib/include/softcut/SubHead.h
@@ -37,6 +37,9 @@ namespace softcut {
         sample_t peek4();
         unsigned int wrapBufIndex(int x);
 
+        void pokeResampling(int nframes);
+        void pokeNoResampling(sample_t in);
+
     protected:
         static constexpr int blockSize = 2048;
         sample_t peek();

--- a/softcut-lib/include/softcut/Voice.h
+++ b/softcut-lib/include/softcut/Voice.h
@@ -89,6 +89,8 @@ namespace softcut {
 
         void setPhaseOffset(float x);
 
+        void setInterpolation(int mode);
+
         phase_t getQuantPhase();
 
         bool getPlayFlag();

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -222,6 +222,11 @@ void ReadWriteHead::setPre(float x) {
     pre = x;
 }
 
+void ReadWriteHead::setInterpolation(int mode) {
+    head[0].setInterpolation(mode);
+    head[1].setInterpolation(mode);
+}
+
 phase_t ReadWriteHead::getActivePhase() {
   return head[active].phase();
 }

--- a/softcut-lib/src/SubHead.cpp
+++ b/softcut-lib/src/SubHead.cpp
@@ -20,6 +20,7 @@ void SubHead::init(FadeCurves *fc) {
     resamp_.setPhase(0);
     inc_dir_ = 1;
     recOffset_ = -8;
+    interpolationMode_ = INTERPOLATE_CUBIC;
 }
 
 Action SubHead::updatePhase(phase_t start, phase_t end, bool loop) {
@@ -164,6 +165,11 @@ void SubHead::setPhase(phase_t phase) {
     // NB: not resetting the resampler here:
     // - it's ok to keep history of input when changing positions.
     // - resamp output doesn't need clearing b/c we write/read from beginning on each sample anyway
+}
+
+void SubHead::setInterpolation(int mode) {
+    interpolationMode_ = mode;
+    resamp_.setInterpolationMode(mode);
 }
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/softcut-lib/src/SubHead.cpp
+++ b/softcut-lib/src/SubHead.cpp
@@ -151,7 +151,34 @@ void SubHead::pokeResampling(int nframes) {
 }
 
 float SubHead::peek() {
-    return peek4();
+    switch(interpolationMode_) {
+        case INTERPOLATE_ZERO_NO_RESAMPLE:
+        case INTERPOLATE_ZERO:
+            return peek1();
+        case INTERPOLATE_LINEAR:
+            return peek2();
+        case INTERPOLATE_CUBIC:
+        default:
+            return peek4();
+    }
+}
+
+float SubHead::peek1() {
+    int phase1 = static_cast<int>(phase_);
+    float y1 = buf_[wrapBufIndex(phase1)];
+
+    return y1;
+}
+
+float SubHead::peek2() {
+    int phase1 = static_cast<int>(phase_);
+    int phase0 = phase1 - 1;
+    
+    float y0 = buf_[wrapBufIndex(phase0)];
+    float y1 = buf_[wrapBufIndex(phase1)];
+
+    auto x = static_cast<float>(phase_ - (float)phase1);
+    return y0 + (y1 - y0) * x;
 }
 
 float SubHead::peek4() {

--- a/softcut-lib/src/Voice.cpp
+++ b/softcut-lib/src/Voice.cpp
@@ -282,6 +282,10 @@ void Voice::setPhaseOffset(float x) {
     phaseOffset = x * sampleRate;
 }
 
+void Voice::setInterpolation(int mode) {
+    sch.setInterpolation(mode);
+}
+
 
 phase_t Voice::getQuantPhase() {
     return quantPhase.load(std::memory_order_relaxed);


### PR DESCRIPTION
not something off the issues list, so apologies if these changes are unwanted, but I’ve been enjoying this feature & I wanted to see if it made sense for upstream norns softcut : )

it’s a command for setting recording+playback interpolation. it also disables resampling entirely on the lowest setting (like max/msp poke~ & friends). right now it works like this:
```
softcut.interpolation(0) -- no interpolation, no resampling
softcut.interpolation(1) -- no interpolation
softcut.interpolation(2) -- linear interpolation
softcut.interpolation(4) -- cubic interpolation
```

I tried keeping the interface as simple as possible to start off, but I could see a couple of changes to make it more intuitive / flexible
- text flags instead of integers (I copied the `GrainBuf` interpolation arg for the current format)
- since it’s one command controlling write interpolation, read interpolation, and resampling on/off I could see splitting it up into 2 or 3 separate commands. 

I’ve more or less just translated some of the preprocessor directives for this into runtime flags, so apologies if there’s some obvious or needed optimizations I’m missing. the main changes are in the `Resampler` & `Subhead` classes, where I added a few alternate pathways based on the 4 states of the command.

## testing

use this `norns` PR for this `softcut-lib` PR: https://github.com/monome/norns/pull/1503

build procedure (copied this from zack's last PR, hopefully I got it right):
```
# get everything
cd ~/norns
git remote set-url origin https://github.com/andr-ew/norns.git
git pull
git checkout sc-interpolation-modes
cd ~/norns/crone/softcut/softcut-lib
git remote set-url origin https://github.com/andr-ew/softcut-lib.git
git pull 
git checkout sc-interpolation-modes
# compile everything
cd ~/norns/crone/softcut/softcut-lib && ./waf && cd ~/norns && ./waf
# restart norns
sudo systemctl restart norns-jack.service; sudo systemctl restart norns-matron.service; sudo systemctl restart norns-crone.service
```
test script (requires some audio input):
```
-- softcut interpolation options test
--
-- E1: pre_level
-- E2: rate (course)
-- E3: rate (fine)
-- K1: clear
-- K2: record into half second loop
-- K3: interpolation mode

tab = require 'tabutil'

interps = {
    0,
    1,
    2,
    4,
}
interp_names = {
    'none, noresamp',
    'none',
    'linear',
    'cubic',
}

interp = 4
rate = 1
pre = 0
rec = false
dur = 0.5

function update_interp()
    softcut.interpolation(1, interps[interp])
end

function set_rec(v)
    rec = v
    softcut.rec_level(1, v and 1 or 0)
    softcut.pre_level(1, v and pre or 1)
end

function set_rate(v)
    rate = v
    softcut.rate(1, v)
    -- softcut.loop_end(1, util.clamp(0, dur, rate * dur))
end

function init()
    audio.level_cut(1.0)
    audio.level_adc_cut(1)

    softcut.level_input_cut(1, 1, 1)
    softcut.level_input_cut(2, 1, 1)

    softcut.buffer_clear()
    softcut.enable(1, 1)
    softcut.rec(1, 1)
    softcut.play(1, 1)
    softcut.recpre_slew_time(1, 0.1)
    softcut.fade_time(1, 0.1)
    softcut.buffer(1, 1)
    softcut.level(1, 1)
    softcut.rate(1, rate)
    softcut.loop(1, 1)
    softcut.loop_start(1, 0)
    softcut.loop_end(1, dur)
    softcut.position(1, 0)
    softcut.rate_slew_time(1, 0.1)

    update_interp()
    
    set_rec(false)
    set_rate(rate)
    
    redraw()
end

function key(n, z)
    if z==1 then
        if n==1 then
            softcut.buffer_clear()
        elseif n==2 then
            set_rec(not rec)
        elseif n==3 then
            interp = interp % #interp_names + 1
            update_interp()
        end
    
        redraw()
    end
end

function enc(n, d)
    if n==1 then
        pre = util.clamp(pre + (d*0.01), 0, 1)
        set_rec(rec)
    elseif n==2 then
        if d > 0 then set_rate(rate * 2)
        elseif d < 0 then set_rate(rate / 2)
        end
    elseif n==3 then
        set_rate(rate + d*0.01)
    end

    redraw()
end

function redraw()
    screen.clear()

    screen.move(2,64 * 1/4)
    screen.text("pre: " ..pre)

    screen.move(2,64 * 1/2)
    screen.text("rate: " .. rate)
    
    screen.move(2, 64 * 3/4)
    screen.text("rec: " .. (rec and "on" or "off"))
    
    screen.move(128 * 1/3, 64 * 3/4)
    screen.text("interp: " .. interp_names[interp])

    screen.update()
end
```
(also, I can’t get the command to show up in the api docs when I build it, not sure what I did wrong)