### PR TITLE
Remove boost from lib

### DIFF
--- a/softcut-lib/include/softcut/Resampler.h
+++ b/softcut-lib/include/softcut/Resampler.h
@@ -5,10 +5,10 @@
 #ifndef SoftcutHEAD_RESAMPLER_H
 #define SoftcutHEAD_RESAMPLER_H
 
-#include <iostream>
+#include <cmy_assert>
 #include <cmath>
+#include <iostream>
 
-#include <boost/assert.hpp>
 #include "Types.h"
 #include "Interpolate.h"
 
@@ -156,7 +156,7 @@ namespace softcut {
             // we need to produce a fractional interpolation coefficient,
             // by "normalizing" to the output phase period
             phase_t p = phase_ + rate_;
-            BOOST_ASSERT_MSG(p >= 0.0, "resampler encountered negative phase");
+            // assert(p >= 0.0 /*resampler encountered negative phase*/);
             auto nf = static_cast<unsigned int>(p);
             if (nf > 0) {
                 phase_t f = 1.0 - phase_;

--- a/softcut-lib/include/softcut/Resampler.h
+++ b/softcut-lib/include/softcut/Resampler.h
@@ -5,7 +5,7 @@
 #ifndef SoftcutHEAD_RESAMPLER_H
 #define SoftcutHEAD_RESAMPLER_H
 
-#include <cmy_assert>
+#include <cassert>
 #include <cmath>
 #include <iostream>
 

--- a/softcut-lib/include/softcut/SoftClip.h
+++ b/softcut-lib/include/softcut/SoftClip.h
@@ -7,6 +7,8 @@
 
 #include <cmath>
 
+#include "softcut/Utilities.h"
+
 namespace softcut {
 
     // two-stage quadratic soft clipper with variable gain
@@ -19,11 +21,6 @@ namespace softcut {
         float g;  // gain multiplier
         float a;  // parabolic coefficient
         float b;  // parabolic offset ( = max level)
-
-        static inline float fsign(float f) {
-            return f > 0.f? 1.f : -1.f; 
-        }
-
         // update quad multiplier from current settings
         void calcCoeffs() {
             // match derivative at knee point

--- a/softcut-lib/include/softcut/SoftClip.h
+++ b/softcut-lib/include/softcut/SoftClip.h
@@ -20,7 +20,9 @@ namespace softcut {
         float a;  // parabolic coefficient
         float b;  // parabolic offset ( = max level)
 
-        static inline float fsign(float f){ return f > 0.f? 1.f : -1.f; }
+        static inline float fsign(float f) {
+            return f > 0.f? 1.f : -1.f; 
+        }
 
         // update quad multiplier from current settings
         void calcCoeffs() {

--- a/softcut-lib/include/softcut/SoftClip.h
+++ b/softcut-lib/include/softcut/SoftClip.h
@@ -6,19 +6,21 @@
 #define Softcut_SOFTCLIP_H
 
 #include <cmath>
-#include <boost/math/special_functions/sign.hpp>
 
 namespace softcut {
 
     // two-stage quadratic soft clipper with variable gain
     // nice odd harmonics, kinda carbon-mic sound
     class SoftClip {
+
     private:
 
         float t; // threshold (beginning of knee)
         float g;  // gain multiplier
         float a;  // parabolic coefficient
         float b;  // parabolic offset ( = max level)
+
+        static inline float fsign(float f){ return f > 0.f? 1.f : -1.f; }
 
         // update quad multiplier from current settings
         void calcCoeffs() {
@@ -42,7 +44,7 @@ namespace softcut {
 
         float processSample(float x) {
             float ax = fabs(x);
-            const float sx = static_cast<float>(boost::math::sign(x));
+            const float sx = fsign(x);
 
             if (ax > 1.f) {
                 ax = 1.f;

--- a/softcut-lib/include/softcut/Utilities.h
+++ b/softcut-lib/include/softcut/Utilities.h
@@ -20,6 +20,10 @@ namespace softcut {
     }
 #endif
 
+    static inline float fsign(float x) { 
+        return x > 0.f ? 1.f : -1.f;
+    }
+
     // convert a time-to-convergence to a pole coefficient
     // "ref" argument defines the amount of convergence
     // target ratio is e^ref.

--- a/softcut-lib/src/FadeCurves.cpp
+++ b/softcut-lib/src/FadeCurves.cpp
@@ -4,7 +4,6 @@
 
 #include <cmath>
 #include <algorithm>
-#include <boost/assert.hpp>
 #include <cstring>
 
 #include "softcut/Interpolate.h"
@@ -81,7 +80,8 @@ void FadeCurves::calcRecFade() {
         }
         buf[n] = 1.f;
     } else {
-        BOOST_ASSERT_MSG(false, "undefined fade shape");
+        // undefined shape. oh well
+        return;
     }
     memcpy(recFadeBuf, buf, fadeBufSize*sizeof(float));
 }
@@ -108,14 +108,15 @@ void FadeCurves::calcPreFade() {
             x += phi;
         }
     } else if (recShape == Raised) {
-        BOOST_ASSERT(preShape == Raised);
+        assert(preShape == Raised);
         const float phi = fpi / ( static_cast<float>(nwp*2));
         while (i < nwp) {
             buf[i++] = cosf(x);
             x += phi;
         }
     } else {
-        BOOST_ASSERT_MSG(false, "undefined fade shape");
+        // undefined shape. oh well
+        return;
     }
     while(i<fadeBufSize) { buf[i++] = 0.f; }
     memcpy(preFadeBuf, buf, fadeBufSize*sizeof(float));

--- a/softcut-lib/src/FadeCurves.cpp
+++ b/softcut-lib/src/FadeCurves.cpp
@@ -2,9 +2,11 @@
 // Created by ezra on 11/15/18.
 //
 
+#include <cassert>
 #include <cmath>
-#include <algorithm>
 #include <cstring>
+
+#include <algorithm>
 
 #include "softcut/Interpolate.h"
 #include "softcut/FadeCurves.h"

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <limits>
 
-
 #include "softcut/Interpolate.h"
 #include "softcut/Resampler.h"
 

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -1,6 +1,7 @@
 //
 // Created by ezra on 12/6/17.
 //
+
 #include <cassert>
 #include <cmath>
 #include <limits>

--- a/softcut-lib/src/ReadWriteHead.cpp
+++ b/softcut-lib/src/ReadWriteHead.cpp
@@ -1,6 +1,7 @@
 //
 // Created by ezra on 12/6/17.
 //
+#include <cassert>
 #include <cmath>
 #include <limits>
 
@@ -30,7 +31,7 @@ void ReadWriteHead::processSample(sample_t in, sample_t *out) {
 
     *out = mixFade(head[0].peek(), head[1].peek(), head[0].fade(), head[1].fade());
 
-    BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
+    //  assert(!(head[0].state_ == Playing && head[1].state_ == Playing) /*multiple active heads*/);
 
     head[0].poke(in, pre, rec);
     head[1].poke(in, pre, rec);
@@ -47,8 +48,8 @@ void ReadWriteHead::processSample(sample_t in, sample_t *out) {
 void ReadWriteHead::processSampleNoRead(sample_t in, sample_t *out) {
     (void)out;
 
-    BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
-
+    // assert(!(head[0].state_ == Playing && head[1].state_ == Playing) /*multiple active heads*/);
+    
     head[0].poke(in, pre, rec);
     head[1].poke(in, pre, rec);
 
@@ -64,7 +65,7 @@ void ReadWriteHead::processSampleNoWrite(sample_t in, sample_t *out) {
     (void)in;
     *out = mixFade(head[0].peek(), head[1].peek(), head[0].fade(), head[1].fade());
 
-    BOOST_ASSERT_MSG(!(head[0].state_ == Playing && head[1].state_ == Playing), "multiple active heads");
+    // assert(!(head[0].state_ == Playing && head[1].state_ == Playing) /*multiple active heads*/);
 
     takeAction(head[0].updatePhase(start, end, loopFlag));
     takeAction(head[1].updatePhase(start, end, loopFlag));
@@ -131,8 +132,8 @@ void ReadWriteHead::cutToPhase(phase_t pos) {
 
     if(s == State::FadeIn || s == State::FadeOut) {
 	// should never enter this condition
-	// std::cerr << "badness! we performed a cut while still fading" << std::endl;
-	return;
+	    std::cerr << "badness! performed a cut while still fading" << std::endl;
+	    return;
     }
 
     // activate the inactive head

--- a/softcut-lib/src/SubHead.cpp
+++ b/softcut-lib/src/SubHead.cpp
@@ -1,13 +1,15 @@
-//
+    //
 // Created by ezra on 4/21/18.
 //
 
+#include <cassert>
 #include <string.h>
 #include <limits>
 
 #include "softcut/Interpolate.h"
 #include "softcut/FadeCurves.h"
 #include "softcut/SubHead.h"
+#include "softcut/Utilities.h"
 
 using namespace softcut;
 
@@ -103,7 +105,7 @@ void SubHead::poke(float in, float pre, float rec) {
         return;
     }
 
-    BOOST_ASSERT_MSG(fade_ >= 0.f && fade_ <= 1.f, "bad fade coefficient in poke()");
+    // assert(fade_ >= 0.f && fade_ <= 1.f /* bad fade coefficient in poke() */);
 
     preFade_ = pre + (1.f-pre) * fadeCurves->getPreFadeValue(fade_);
     recFade_ = rec * fadeCurves->getRecFadeValue(fade_);
@@ -149,7 +151,7 @@ float SubHead::peek4() {
 
 unsigned int SubHead::wrapBufIndex(int x) {
     x += bufFrames_;
-    BOOST_ASSERT_MSG(x >= 0, "buffer index before masking is non-negative");
+    // assert(x >= 0 /* buffer index before masking is non-negative */);
     return x & bufMask_;
 }
 
@@ -172,12 +174,12 @@ void SubHead::setBuffer(float *buf, unsigned int frames) {
     buf_  = buf;
     bufFrames_ = frames;
     bufMask_ = frames - 1;
-    BOOST_ASSERT_MSG((bufFrames_ != 0) && !(bufFrames_ & bufMask_), "buffer size is not 2^N");
+    assert((bufFrames_ != 0) && !(bufFrames_ & bufMask_) /*buffer size is not 2^N*/);
 }
 
 void SubHead::setRate(rate_t rate) {
     rate_ = rate;
-    inc_dir_ = boost::math::sign(rate);
+    inc_dir_ = fsign(rate);
     // NB: resampler doesn't handle negative rates.
     // instead we copy the resampler output backwards into the buffer when rate < 0.
     resamp_.setRate(std::fabs(rate));


### PR DESCRIPTION
remove use of boost functions in softcut-lib code.

these are pretty trivial: assertions and floating `sign` function.

in particular, the assertions have been replaced with standard `assert`, with a hackier method of adding a failure message. but since none of these assertions have been hit in the last 5 years, i've also felt comfortable just commenting most of them out. (with the one exception of illegal buffer sizes.)